### PR TITLE
owntracks maps: render as JPEG q85 instead of PNG

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Pocket and Google Photos were formerly data sources. The Google Photos integrati
 | `*_connector.py` | One connector class per external service (Spotify, Google Calendar, Joplin, Nextcloud, Habitica, Raindrop, OwnTracks); `pocket_connector.py` is database-only since the Pocket API shut down; `dictionary_connector.py` is a single function over dictionaryapi.dev |
 | `owntracks_track.py` | Pure functions turning raw location fixes into stays and links (no I/O) |
 | `spelling_bee.py` | Pure functions rebuilding a NYT Spelling Bee hive from the words missed that day (no I/O) |
-| `map_render.py` | Renders the daily location map to PNG (py-staticmaps + Pillow) |
+| `map_render.py` | Renders the daily location map to an image (py-staticmaps + Pillow); `RenderParams` holds size and encoding, JPEG q85 by default |
 | `owntracks_maps.py` | Puts a rendered map into its Joplin note's Location section |
 
 The diary entry format is a Markdown document with named sections (words, images, Google Calendar events, Spotify tracks; older entries also have a Pocket articles section). `MyDiaryDay.init_markdown()` generates the template; Joplin stores the actual notes.
@@ -44,7 +44,7 @@ Vue 3 SPA using Vuetify 4 and Pinia for state. Key views: `MyDiaryDay.vue` (main
 
 The Spelling Bee tracker records words missed in the NYT puzzle, entered by hand. Its one non-obvious idea: every word in a puzzle is built from the same seven letters and every word contains the centre letter, so a playable hive can be reconstructed from the words alone — recording the letters (`SpellingBeePuzzle`, optional, one row per date) only makes it exact. `spelling_bee.py` owns that derivation; `SpellingBeeHive.vue` is a dumb renderer. Word helpers are mirrored in `src/spellingBee.ts` so the entry form can validate a paste as it is typed.
 
-`MapSection.vue` draws the day's location track with Leaflet, from the same `/owntracks/track/{dt}` endpoint the PNG renderer uses, and exposes the smoothing thresholds as sliders for tuning.
+`MapSection.vue` draws the day's location track with Leaflet, from the same `/owntracks/track/{dt}` endpoint the map renderer uses, and exposes the smoothing thresholds as sliders for tuning.
 
 `api.ts` is **auto-generated** from the FastAPI OpenAPI spec via [Orval](https://orval.dev/) — do not edit it by hand.
 
@@ -116,7 +116,16 @@ docker compose exec mydiary-vuetify npm run lint
 
 `npm run lint` currently reports ~27 pre-existing `no-unused-vars` errors, mostly in `Test.vue` / `TestDay.vue`. Compare counts before and after a change rather than expecting a clean run.
 
-To see a UI change rendered, drive the running app with Playwright — it is installed in the **backend** venv (`backend/.venv/bin/python`), not in the frontend. Screenshot at 1440×900 and 390×844, and scroll the page before capturing: `v-img` lazy-loads via IntersectionObserver, so an unscrolled full-page screenshot shows blank gaps where photos should be.
+To see a UI change rendered, drive the running app with the Playwright MCP tools (`mcp__playwright__*`) — don't write a standalone Playwright script against the backend venv, the MCP tools already cover navigate/resize/scroll/screenshot with no script to maintain. Resize to 1440×900 and 390×844, and scroll the page before capturing: `v-img` lazy-loads via IntersectionObserver, so an unscrolled full-page screenshot shows blank gaps where photos should be. Pass `browser_take_screenshot` a `filename` under `.playwright-mcp/` (e.g. `.playwright-mcp/foo.png`) — a bare relative name saves to the repo root instead of that gitignored output directory.
+
+The Playwright MCP server must run **Firefox** in an **isolated** context (`--browser firefox --isolated`), not the `@playwright/mcp` default of Chromium. This is set in `.mcp.json` at the repo root, which is gitignored (local machine setup, not shared) — if that file is missing or a session is defaulting to Chromium, add this entry under its `mcpServers` key (alongside the existing `mydiary` entry) and make sure `"playwright"` is listed in `.claude/settings.local.json`'s `enabledMcpjsonServers`:
+
+```json
+"playwright": {
+  "command": "npx",
+  "args": ["@playwright/mcp@latest", "--browser", "firefox", "--isolated"]
+}
+```
 
 ### Database migrations (from `backend/`)
 

--- a/backend/mydiary/api.py
+++ b/backend/mydiary/api.py
@@ -890,9 +890,9 @@ def owntracks_track_for_day(
 
 
 @app.get(
-    "/owntracks/map/{dt}.png",
+    "/owntracks/map/{dt}",
     operation_id="owntracksDayMapImage",
-    responses={200: {"content": {"image/png": {}}}},
+    responses={200: {"content": {"image/jpeg": {}}}},
 )
 def owntracks_day_map_image(
     dt: str,
@@ -900,6 +900,8 @@ def owntracks_day_map_image(
     tz: str = "infer",
     width: int = 1200,
     height: int = 900,
+    fmt: str = "JPEG",
+    quality: int = 85,
     max_acc: int = 100,
     stay_radius_m: float = 150.0,
     stay_minutes: float = 20.0,
@@ -908,24 +910,29 @@ def owntracks_day_map_image(
     dwell_max_kmh: float = 1.0,
     session: Session = Depends(get_session),
 ):
+    from .map_render import RenderParams
     from .owntracks_maps import render_for_day
 
     dt_obj = _owntracks_day(dt, tz, session)
     params = _track_params(
         max_acc, stay_radius_m, stay_minutes, gap_minutes, gap_metres, dwell_max_kmh
     )
+    render = RenderParams(width=width, height=height, fmt=fmt, quality=quality)
     try:
-        png, _, content_hash = render_for_day(
-            dt_obj, session, params, width=width, height=height
-        )
+        media_type = render.media_type
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    try:
+        data, _, content_hash = render_for_day(dt_obj, session, params, render)
     except LookupError as e:
         raise HTTPException(status_code=404, detail=str(e))
-    etag = f'"{content_hash}-{width}x{height}"'
+    # the content hash covers geometry and encoding on its own
+    etag = f'"{content_hash}"'
     if request.headers.get("if-none-match") == etag:
         return Response(status_code=304)
     return Response(
-        content=png,
-        media_type="image/png",
+        content=data,
+        media_type=media_type,
         headers={"ETag": etag, "Cache-Control": "private, max-age=3600"},
     )
 

--- a/backend/mydiary/joplin_connector.py
+++ b/backend/mydiary/joplin_connector.py
@@ -357,6 +357,16 @@ class MyDiaryJoplin:
         )
         return r.status_code == 200
 
+    def get_resource_size(self, resource_id: str) -> Optional[int]:
+        """Bytes stored for a resource, without downloading the file itself."""
+        r = requests.get(
+            f"{self.base_url}/resources/{resource_id}",
+            params={"token": self.token, "fields": "size"},
+        )
+        if r.status_code != 200:
+            return None
+        return r.json().get("size")
+
     def create_resource(
         self,
         data: bytes,

--- a/backend/mydiary/map_render.py
+++ b/backend/mydiary/map_render.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-DESCRIPTION = """Draw a day's movement as a PNG.
+DESCRIPTION = """Draw a day's movement as an image.
 
 py-staticmaps handles the parts that are the same for any map -- fitting the
 bounds, picking a zoom, fetching and caching tiles -- and this module supplies
@@ -15,6 +15,7 @@ PIL.ImageDraw has none of its own."""
 
 import io
 import math
+from dataclasses import dataclass
 from typing import List, Optional, Sequence, Tuple
 
 import s2sphere
@@ -60,6 +61,59 @@ DASH_ON = 7
 DASH_OFF = 6
 LABEL_MIN_MINUTES = 60
 FOOTER_HEIGHT = 34
+
+# fmt -> (file extension, media type)
+FORMATS = {
+    "JPEG": ("jpg", "image/jpeg"),
+    "PNG": ("png", "image/png"),
+    "WEBP": ("webp", "image/webp"),
+}
+_FORMAT_ALIASES = {"JPG": "JPEG"}
+
+
+@dataclass(frozen=True)
+class RenderParams:
+    """Size and encoding of the output image, in one place.
+
+    JPEG rather than PNG: a tile basemap is photographic, so PNG buys nothing
+    and costs ~5x the bytes (996KB vs 219KB on 2026-07-01, 1290KB vs 235KB on
+    2026-07-30), which lands in every diary note forever. At q85 the footer
+    text and street labels are indistinguishable from the PNG at 1:1.
+
+    quality is ignored for PNG. Same cache_key() shape as TrackParams, so the
+    two compose into one content hash.
+    """
+
+    width: int = 1200
+    height: int = 900
+    fmt: str = "JPEG"
+    quality: int = 85
+
+    @property
+    def format(self) -> str:
+        """The Pillow format name, normalised (jpg -> JPEG)."""
+        fmt = self.fmt.upper()
+        fmt = _FORMAT_ALIASES.get(fmt, fmt)
+        if fmt not in FORMATS:
+            raise ValueError(
+                f"unsupported image format {self.fmt!r}; "
+                f"expected one of {', '.join(sorted(FORMATS))}"
+            )
+        return fmt
+
+    @property
+    def ext(self) -> str:
+        return FORMATS[self.format][0]
+
+    @property
+    def media_type(self) -> str:
+        return FORMATS[self.format][1]
+
+    def cache_key(self) -> str:
+        # normalised fmt, so "jpg" and "JPEG" are not two different keys and
+        # do not each trigger a re-render and a fresh Joplin resource
+        fields = dict(self.__dict__, fmt=self.format)
+        return "|".join(f"{k}={v}" for k, v in sorted(fields.items()))
 
 
 class RetinaTileProvider(TileProvider):
@@ -380,17 +434,18 @@ def _draw_footer(image: Image.Image, track: DayTrack, width: int, top: int) -> N
 def render_day_map(
     track: DayTrack,
     params: Optional[TrackParams] = None,
-    width: int = 1200,
-    height: int = 900,
+    render: Optional[RenderParams] = None,
     tile_downloader=None,
 ) -> bytes:
-    """Render a day's track to PNG bytes.
+    """Render a day's track to encoded image bytes.
 
     tile_downloader is only for tests; leaving it None uses the real, cached one.
     """
     if track.is_empty():
         raise ValueError("cannot render a map for a day with no location data")
 
+    render = render or RenderParams()
+    width, height = render.width, render.height
     cache_dir = str(thumbnail_cache.get_cache_dir(subdir="map_tiles"))
     map_height = height - FOOTER_HEIGHT
 
@@ -425,5 +480,14 @@ def render_day_map(
     _draw_footer(canvas, track, width, map_height)
 
     buf = io.BytesIO()
-    canvas.save(buf, format="PNG", optimize=True)
+    fmt = render.format
+    if fmt == "JPEG":
+        # subsampling=0 (4:4:4) is not the default and matters here: the track
+        # is thin saturated colour over a near-grey basemap, which is exactly
+        # what 4:2:0 chroma subsampling smears. canvas is already RGB.
+        canvas.save(buf, format=fmt, quality=render.quality, optimize=True, subsampling=0)
+    elif fmt == "WEBP":
+        canvas.save(buf, format=fmt, quality=render.quality)
+    else:
+        canvas.save(buf, format=fmt, optimize=True)
     return buf.getvalue()

--- a/backend/mydiary/owntracks_maps.py
+++ b/backend/mydiary/owntracks_maps.py
@@ -7,6 +7,7 @@ MyDiaryImage and the photo grid: it lives in its own Location section and its
 own bookkeeping table. That table exists so a re-render of an unchanged day
 reuses its Joplin resource rather than orphaning one."""
 
+import hashlib
 from datetime import datetime
 from typing import Optional, Tuple
 
@@ -15,7 +16,7 @@ from sqlmodel import Session, select
 
 from .db import engine
 from .joplin_connector import MyDiaryJoplin
-from .map_render import render_day_map
+from .map_render import RenderParams, render_day_map
 from .markdown_edits import MarkdownDoc
 from .models import OwnTracksDayMap
 from .mydiary_day import MyDiaryDay
@@ -36,11 +37,17 @@ def render_for_day(
     dt: datetime,
     session: Session,
     params: Optional[TrackParams] = None,
-    width: int = 1200,
-    height: int = 900,
+    render: Optional[RenderParams] = None,
 ) -> Tuple[bytes, DayTrack, str]:
-    """Render the map for a day. Returns (png, track, content_hash)."""
+    """Render the map for a day. Returns (image bytes, track, content_hash).
+
+    The hash covers the render parameters as well as the track, so changing the
+    size or the encoding invalidates a stored map the same way new location
+    data does. It is composed here rather than in owntracks_track, which is
+    pure track maths and has no business knowing about image encoding.
+    """
     params = params or TrackParams()
+    render = render or RenderParams()
     mydiary_owntracks = MyDiaryOwnTracks()
     locations = mydiary_owntracks.get_locations_for_day(dt, session=session)
     if not locations:
@@ -56,8 +63,11 @@ def render_for_day(
             f"no usable location data for {dt.to_date_string()} "
             f"({len(locations)} fixes, all filtered out)"
         )
-    png = render_day_map(track, params, width=width, height=height)
-    return png, track, track.content_hash(params)
+    data = render_day_map(track, params, render)
+    content_hash = hashlib.sha256(
+        f"{track.content_hash(params)}|{render.cache_key()}".encode()
+    ).hexdigest()
+    return data, track, content_hash
 
 
 def sync_day_map_to_note(
@@ -66,6 +76,7 @@ def sync_day_map_to_note(
     mydiary_joplin: Optional[MyDiaryJoplin] = None,
     params: Optional[TrackParams] = None,
     force: bool = False,
+    render: Optional[RenderParams] = None,
 ) -> str:
     """Render the day's map, upload it to Joplin, and write the Location section.
 
@@ -80,7 +91,7 @@ def sync_day_map_to_note(
         mydiary_joplin = MyDiaryJoplin(init_config=False)
         mydiary_joplin.__enter__()
     try:
-        return _sync_day_map_to_note(dt, session, mydiary_joplin, params, force)
+        return _sync_day_map_to_note(dt, session, mydiary_joplin, params, force, render)
     finally:
         if close_joplin:
             mydiary_joplin.__exit__(None, None, None)
@@ -94,10 +105,12 @@ def _sync_day_map_to_note(
     mydiary_joplin: MyDiaryJoplin,
     params: Optional[TrackParams],
     force: bool,
+    render: Optional[RenderParams] = None,
 ) -> str:
     dt = pendulum.instance(dt)
     diary_date = dt.date()
-    png, track, content_hash = render_for_day(dt, session, params)
+    render = render or RenderParams()
+    data, track, content_hash = render_for_day(dt, session, params, render)
 
     existing = session.get(OwnTracksDayMap, diary_date)
     if (
@@ -110,11 +123,13 @@ def _sync_day_map_to_note(
         return "no update"
 
     note_id = mydiary_joplin.get_note_id_by_date(dt)
-    if note_id is None:
+    if note_id is None or note_id == "does_not_exist":
         raise LookupError(f"no Joplin note for {diary_date}")
 
+    # Joplin takes the resource's mime from this extension, so it is the only
+    # thing the note needs in order to render a non-PNG map
     r = mydiary_joplin.create_resource(
-        data=png, title=f"map-{diary_date}", ext="png"
+        data=data, title=f"map-{diary_date}", ext=render.ext
     )
     r.raise_for_status()
     resource_id = r.json()["id"]
@@ -163,7 +178,7 @@ def section_content(resource_id: Optional[str], track: DayTrack) -> str:
     """The Location section body: the map, then a searchable itinerary.
 
     The itinerary is the part that keeps working -- Joplin can search text, but
-    it cannot search a PNG.
+    it cannot search an image.
     """
     from .owntracks_track import summary_label
     from .models import make_markdown_table_header

--- a/backend/scripts/owntracks_reencode_maps.py
+++ b/backend/scripts/owntracks_reencode_maps.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+
+DESCRIPTION = """Re-encode the OwnTracks maps already embedded in Joplin notes.
+
+The maps used to be saved as PNG, which costs roughly 5x the bytes of the JPEG
+they are saved as now for no visible difference. Every day already in
+OwnTracksDayMap is re-rendered and its Joplin resource replaced.
+
+Resumable and safe to re-run: OwnTracksDayMap.content_hash now covers the
+render parameters, so an un-migrated day hashes differently and gets the work,
+while a migrated day hashes equal and is skipped. Run it inside the backend
+container -- JOPLIN_BASE_URL points at host.docker.internal, which does not
+resolve from the host."""
+
+import sys, os
+from datetime import datetime
+from timeit import default_timer as timer
+
+import pendulum
+from sqlmodel import Session, select
+
+try:
+    from humanfriendly import format_timespan
+except ImportError:
+
+    def format_timespan(seconds):
+        return "{:.2f} seconds".format(seconds)
+
+
+import logging
+
+root_logger = logging.getLogger()
+logger = root_logger.getChild(__name__)
+
+from mydiary.core import get_last_timezone
+from mydiary.db import engine
+from mydiary.joplin_connector import MyDiaryJoplin
+from mydiary.models import OwnTracksDayMap
+from mydiary.owntracks_maps import render_for_day, sync_day_map_to_note
+
+
+def format_bytes(num: int) -> str:
+    return f"{num / 1024:,.0f} KB"
+
+
+def start_of_day(diary_date, session: Session) -> pendulum.DateTime:
+    """Start of the day in the day's own timezone, as the API routes do it.
+
+    get_last_timezone raises when TimeZoneChange is empty (todo item 4.3); a
+    backfill must not die on that, so it falls back the same way the routes do.
+    """
+    dt_str = diary_date.isoformat()
+    try:
+        tz = get_last_timezone(dt_str, session=session)
+    except (AttributeError, TypeError):
+        logger.warning("could not infer timezone; falling back to local")
+        tz = "local"
+    return pendulum.parse(dt_str, tz=tz)
+
+
+def main(args):
+    with Session(engine) as session, MyDiaryJoplin(init_config=False) as mydiary_joplin:
+        stmt = select(OwnTracksDayMap).order_by(OwnTracksDayMap.diary_date)
+        if args.start:
+            stmt = stmt.where(
+                OwnTracksDayMap.diary_date >= pendulum.parse(args.start).date()
+            )
+        if args.end:
+            stmt = stmt.where(
+                OwnTracksDayMap.diary_date <= pendulum.parse(args.end).date()
+            )
+        if args.limit:
+            stmt = stmt.limit(args.limit)
+        rows = session.exec(stmt).all()
+        logger.info(f"{len(rows)} day map(s) to consider")
+
+        total_before = 0
+        total_after = 0
+        num_updated = 0
+        num_skipped = 0
+        num_failed = 0
+
+        for row in rows:
+            diary_date = row.diary_date
+            before = mydiary_joplin.get_resource_size(row.joplin_resource_id)
+            try:
+                dt = start_of_day(diary_date, session)
+                if args.dry_run:
+                    data, _, content_hash = render_for_day(dt, session)
+                    if content_hash == row.content_hash:
+                        logger.info(f"{diary_date}: already up to date")
+                        num_skipped += 1
+                        continue
+                    after = len(data)
+                else:
+                    result = sync_day_map_to_note(
+                        dt, session=session, mydiary_joplin=mydiary_joplin
+                    )
+                    if result == "no update":
+                        logger.info(f"{diary_date}: already up to date")
+                        num_skipped += 1
+                        continue
+                    session.expire(row)
+                    after = mydiary_joplin.get_resource_size(row.joplin_resource_id)
+            except LookupError as e:
+                # no Joplin note for the day, or no usable location data left
+                logger.warning(f"{diary_date}: skipped -- {e}")
+                num_failed += 1
+                continue
+
+            num_updated += 1
+            if before is None or after is None:
+                logger.info(f"{diary_date}: updated (size unavailable)")
+                continue
+            total_before += before
+            total_after += after
+            logger.info(
+                f"{diary_date}: {format_bytes(before)} -> {format_bytes(after)} "
+                f"({100 * (before - after) / before:.0f}% smaller)"
+            )
+
+        verb = "would update" if args.dry_run else "updated"
+        logger.info(
+            f"{verb} {num_updated}, skipped {num_skipped}, failed {num_failed}"
+        )
+        if total_before:
+            logger.info(
+                f"total: {format_bytes(total_before)} -> {format_bytes(total_after)} "
+                f"(saved {format_bytes(total_before - total_after)}, "
+                f"{100 * (total_before - total_after) / total_before:.0f}%)"
+            )
+
+
+if __name__ == "__main__":
+    total_start = timer()
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        logging.Formatter(
+            fmt="%(asctime)s %(name)s.%(lineno)d %(levelname)s : %(message)s",
+            datefmt="%H:%M:%S",
+        )
+    )
+    root_logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.info(" ".join(sys.argv))
+    logger.info("{:%Y-%m-%d %H:%M:%S}".format(datetime.now()))
+    logger.info("pid: {}".format(os.getpid()))
+    import argparse
+
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument("--start", help="only days on or after this date (YYYY-MM-DD)")
+    parser.add_argument("--end", help="only days on or before this date (YYYY-MM-DD)")
+    parser.add_argument("--limit", type=int, help="stop after this many days")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="render and report sizes without touching Joplin or the database",
+    )
+    parser.add_argument("--debug", action="store_true", help="output debugging info")
+    global args
+    args = parser.parse_args()
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+        logging.getLogger("mydiary").setLevel(logging.DEBUG)
+        logger.debug("debug mode is on")
+    main(args)
+    total_end = timer()
+    logger.info(
+        "all finished. total time: {}".format(format_timespan(total_end - total_start))
+    )

--- a/backend/tests/test_owntracks_maps.py
+++ b/backend/tests/test_owntracks_maps.py
@@ -8,9 +8,10 @@ from PIL import Image
 from sqlmodel import Session, select
 
 from mydiary import owntracks_maps
+from mydiary.map_render import RenderParams
 from mydiary.markdown_edits import MarkdownDoc
 from mydiary.models import JoplinNote, OwnTracksDayMap, OwnTracksLocation
-from mydiary.owntracks_maps import section_content, sync_day_map_to_note
+from mydiary.owntracks_maps import render_for_day, section_content, sync_day_map_to_note
 
 TZ = "America/New_York"
 DAY = "2026-07-01"
@@ -56,6 +57,7 @@ class FakeJoplin:
         self.resources = {}
         self.deleted = []
         self.update_count = 0
+        self.exts = []
 
     def get_note_id_by_date(self, dt):
         return self.note.id
@@ -68,6 +70,7 @@ class FakeJoplin:
 
         resource_id = hashlib.md5(data).hexdigest()
         self.resources[resource_id] = title
+        self.exts.append(ext)
         return FakeResponse({"id": resource_id})
 
     def resource_exists(self, resource_id):
@@ -106,13 +109,9 @@ def offline_tiles(monkeypatch):
     """Render without the network."""
     real_render = owntracks_maps.render_day_map
 
-    def _render(track, params=None, width=1200, height=900, tile_downloader=None):
+    def _render(track, params=None, render=None, tile_downloader=None):
         return real_render(
-            track,
-            params,
-            width=width,
-            height=height,
-            tile_downloader=FakeTileDownloader(),
+            track, params, render, tile_downloader=FakeTileDownloader()
         )
 
     monkeypatch.setattr(owntracks_maps, "render_day_map", _render)
@@ -189,6 +188,24 @@ def test_records_bookkeeping_row(db_with_locations, dt):
     assert row.num_points == 17
 
 
+def test_resource_is_uploaded_as_a_jpeg(db_with_locations, dt):
+    # Joplin takes the resource's mime type from this extension, so it is what
+    # decides whether the note renders the map at all
+    joplin = FakeJoplin()
+    sync_day_map_to_note(dt, session=db_with_locations, mydiary_joplin=joplin)
+    assert joplin.exts == ["jpg"]
+
+
+def test_changing_only_the_render_params_changes_the_content_hash(db_with_locations, dt):
+    # the whole re-encode backfill rides on this: without the render params in
+    # the hash, every already-stored day would look up to date and be skipped
+    _, _, as_jpeg = render_for_day(dt, db_with_locations)
+    _, _, as_png = render_for_day(
+        dt, db_with_locations, render=RenderParams(fmt="PNG")
+    )
+    assert as_jpeg != as_png
+
+
 def test_rerunning_an_unchanged_day_is_a_noop(db_with_locations, dt):
     joplin = FakeJoplin()
     sync_day_map_to_note(dt, session=db_with_locations, mydiary_joplin=joplin)
@@ -212,8 +229,8 @@ def test_force_replaces_the_resource_and_deletes_the_old_one(
     # a different render produces different bytes, hence a different resource
     real_render = owntracks_maps.render_day_map
 
-    def _bigger(track, params=None, width=1200, height=900, tile_downloader=None):
-        return real_render(track, params, width=640, height=480)
+    def _bigger(track, params=None, render=None, tile_downloader=None):
+        return real_render(track, params, RenderParams(width=640, height=480))
 
     monkeypatch.setattr(owntracks_maps, "render_day_map", _bigger)
     result = sync_day_map_to_note(
@@ -227,6 +244,17 @@ def test_force_replaces_the_resource_and_deletes_the_old_one(
 def test_missing_location_data_raises_lookup_error(db_session, dt):
     with pytest.raises(LookupError):
         sync_day_map_to_note(dt, session=db_session, mydiary_joplin=FakeJoplin())
+
+
+def test_a_day_with_no_note_raises_lookup_error(db_with_locations, dt):
+    # get_note_id_by_date returns the string "does_not_exist", never None, so
+    # a None-only check let this fall through into the Joplin calls instead --
+    # which the re-encode backfill catches per day and would have died on
+    joplin = FakeJoplin()
+    joplin.get_note_id_by_date = lambda _dt: "does_not_exist"
+    with pytest.raises(LookupError):
+        sync_day_map_to_note(dt, session=db_with_locations, mydiary_joplin=joplin)
+    assert not joplin.resources  # and no orphan resource was uploaded first
 
 
 def test_backfills_the_section_into_a_note_that_lacks_it(db_with_locations, dt):

--- a/backend/tests/test_owntracks_render.py
+++ b/backend/tests/test_owntracks_render.py
@@ -7,7 +7,7 @@ import pytest
 from PIL import Image
 
 from mydiary import map_render
-from mydiary.map_render import FOOTER_HEIGHT, render_day_map, stay_radius
+from mydiary.map_render import FOOTER_HEIGHT, RenderParams, render_day_map, stay_radius
 from mydiary.owntracks_track import TrackPoint, build_track
 
 TZ = "America/New_York"
@@ -58,15 +58,44 @@ def july1_track(rootdir: str):
     return build_track(points)
 
 
-def test_renders_a_png_of_the_requested_size(july1_track, downloader):
-    png = render_day_map(july1_track, width=800, height=600, tile_downloader=downloader)
-    image = Image.open(io.BytesIO(png))
-    assert image.format == "PNG"
+def test_renders_a_jpeg_of_the_requested_size(july1_track, downloader):
+    data = render_day_map(
+        july1_track, render=RenderParams(width=800, height=600), tile_downloader=downloader
+    )
+    image = Image.open(io.BytesIO(data))
+    assert image.format == "JPEG"
     assert image.size == (800, 600)
 
 
+def test_png_is_still_available(july1_track, downloader):
+    # the escape hatch for anything that needs lossless output
+    data = render_day_map(
+        july1_track,
+        render=RenderParams(width=400, height=300, fmt="PNG"),
+        tile_downloader=downloader,
+    )
+    image = Image.open(io.BytesIO(data))
+    assert image.format == "PNG"
+    assert image.size == (400, 300)
+
+
+def test_render_params_describe_their_encoding():
+    assert RenderParams().ext == "jpg"
+    assert RenderParams().media_type == "image/jpeg"
+    assert RenderParams(fmt="png").ext == "png"  # normalised, not case-sensitive
+    assert RenderParams(fmt="jpg").cache_key() == RenderParams(fmt="JPEG").cache_key()
+
+
+def test_render_params_reject_an_unknown_format():
+    # the API takes fmt as a query parameter, so this is a 400, not a 500
+    with pytest.raises(ValueError):
+        RenderParams(fmt="tiff").media_type
+
+
 def test_render_fetches_both_basemap_and_label_tiles(july1_track, downloader):
-    render_day_map(july1_track, width=400, height=300, tile_downloader=downloader)
+    render_day_map(
+        july1_track, render=RenderParams(width=400, height=300), tile_downloader=downloader
+    )
     providers = {name for name, _, _, _ in downloader.requested}
     assert providers == {
         map_render.BASEMAP_PROVIDER.name(),
@@ -77,21 +106,31 @@ def test_render_fetches_both_basemap_and_label_tiles(july1_track, downloader):
 def test_render_makes_no_network_calls(july1_track, downloader):
     # the fake downloader is the only tile source; if anything else reached out
     # this test would be slow and flaky rather than hermetic
-    render_day_map(july1_track, width=400, height=300, tile_downloader=downloader)
+    render_day_map(
+        july1_track, render=RenderParams(width=400, height=300), tile_downloader=downloader
+    )
     assert downloader.requested
 
 
 def test_footer_is_drawn_below_the_map(july1_track, downloader):
-    png = render_day_map(july1_track, width=800, height=600, tile_downloader=downloader)
-    image = Image.open(io.BytesIO(png)).convert("RGB")
+    # rendered as PNG so the assertion is about what was drawn rather than
+    # about how much JPEG nudged a flat colour
+    data = render_day_map(
+        july1_track,
+        render=RenderParams(width=800, height=600, fmt="PNG"),
+        tile_downloader=downloader,
+    )
+    image = Image.open(io.BytesIO(data)).convert("RGB")
     # the legend strip sits on the surface colour, not on tile grey
     assert image.getpixel((400, 600 - FOOTER_HEIGHT // 2)) == map_render.SURFACE
 
 
 def test_render_is_deterministic(july1_track, downloader):
-    first = render_day_map(july1_track, width=400, height=300, tile_downloader=downloader)
+    first = render_day_map(
+        july1_track, render=RenderParams(width=400, height=300), tile_downloader=downloader
+    )
     second = render_day_map(
-        july1_track, width=400, height=300, tile_downloader=FakeTileDownloader()
+        july1_track, render=RenderParams(width=400, height=300), tile_downloader=FakeTileDownloader()
     )
     assert first == second
 
@@ -110,7 +149,7 @@ def test_render_survives_a_flight_day(downloader):
         TrackPoint(base.add(hours=7), 26.782, -82.2279),
     ]
     png = render_day_map(
-        build_track(points), width=600, height=450, tile_downloader=downloader
+        build_track(points), render=RenderParams(width=600, height=450), tile_downloader=downloader
     )
     assert Image.open(io.BytesIO(png)).size == (600, 450)
 

--- a/docs/location-workflow.md
+++ b/docs/location-workflow.md
@@ -31,7 +31,7 @@ everything downstream:
 
 ```
 recorder ──> OwnTracksLocation ──> owntracks_track ──> map_render ──> Joplin
-  (API)         (SQLite)            (stays/links)        (PNG)      (Location §)
+  (API)         (SQLite)            (stays/links)       (JPEG)      (Location §)
                                           │
                                           └──> /owntracks/track/{dt} ──> MapSection.vue
 ```
@@ -96,6 +96,40 @@ Details worth knowing:
   Pillow ≥ 10.1, so nothing needs vendoring into the fontless base image.
 - The bundled Carto providers use `http://`; ours override to https.
 
+### Encoding
+
+`RenderParams` (size + format + quality) is the second half of the render
+config, alongside `TrackParams`. The default is **JPEG q85 at 4:4:4, 1200×900**.
+
+The output was PNG until 2026-08, which cost about 5× the bytes for no visible
+gain — a tile basemap is photographic, and PNG only pays off for the flat colour
+and text in the footer strip. Measured at 1200×900 on two real days:
+
+| Encoding | 2026-07-01 | 2026-07-30 |
+|---|---|---|
+| PNG `optimize=True` | 996 KB | 1290 KB |
+| PNG, 64-colour palette | 367 KB | 500 KB |
+| **JPEG q85, 4:4:4** | **219 KB** | **235 KB** |
+| WebP q80 | 107 KB | 125 KB |
+
+Side-by-side 1:1 crops of the footer legend and of street labels over the track
+were indistinguishable across all three. JPEG rather than the smaller WebP
+because these images are meant to still open in thirty years. Size was kept at
+1200×900: once the format changed, pixels stopped being the expensive part, and
+street labels need them.
+
+Two things that are easy to get wrong here:
+
+- **`subsampling=0` (4:4:4) is not the default and is load-bearing.** The track
+  is thin saturated colour over a near-grey basemap, which is precisely what
+  4:2:0 chroma subsampling smears.
+- **`compress_level` is a dead end for PNG.** Pillow's `optimize=True` already
+  implies level 9; 6 and 9 produce byte-identical output.
+
+`RenderParams(fmt="PNG")` and `fmt="WEBP"` still work — the escape hatch is one
+query parameter — and `cache_key()` normalises the format name so `jpg` and
+`JPEG` do not hash as two different encodings.
+
 ### Visual encoding
 
 Time of day is **four labelled periods, not a continuous gradient** — on a map
@@ -131,14 +165,22 @@ beneath. Only stays over an hour get a duration label.
 - Uploads via `create_resource`, **not** `create_thumbnail` — the latter's 60KB
   ceiling would destroy the map. No `MyDiaryImage` row is created either, or the
   map would leak into the photo grid and the Images section.
-- `OwnTracksDayMap` records `content_hash` (the processed track plus render
-  params). An unchanged re-run is a no-op; a changed one creates the new
+- `OwnTracksDayMap` records `content_hash` — `sha256` over the track's own hash
+  plus `RenderParams.cache_key()`, composed in `render_for_day` rather than in
+  `owntracks_track`, which is pure track maths and should not know about image
+  encoding. An unchanged re-run is a no-op; a changed one creates the new
   resource and deletes the old, so re-rendering never orphans resources.
+  Because the render params are in the hash, changing the size or the format is
+  enough on its own to invalidate every stored day — which is what makes
+  `scripts/owntracks_reencode_maps.py` work without `force`, and makes it
+  resumable: a day already re-encoded hashes equal and is skipped.
+- `create_resource(ext=render.ext)` is what makes a non-PNG map render in the
+  note at all: Joplin derives the resource's mime type from that extension.
 - Old notes predating this feature have no Location section, and
   `update_joplin_note` skips sections it does not find. `MarkdownDoc.ensure_section`
   is what backfills it.
 - The section holds the map **and** a text itinerary. The itinerary is the part
-  that keeps working: Joplin can search text, it cannot search a PNG.
+  that keeps working: Joplin can search text, it cannot search an image.
 
 ## Routes
 
@@ -146,7 +188,7 @@ beneath. Only stays over an hour get a duration label.
 |---|---|
 | `GET /owntracks/locations/{dt}` | `owntracksLocationsForDay` — raw fixes |
 | `GET /owntracks/track/{dt}` | `owntracksTrackForDay` — processed stays + links |
-| `GET /owntracks/map/{dt}.png` | `owntracksDayMapImage` |
+| `GET /owntracks/map/{dt}` | `owntracksDayMapImage` — JPEG by default; `fmt` / `quality` / `width` / `height` |
 | `POST /owntracks/sync` | `owntracksSyncLocations` |
 | `POST /owntracks/map/{dt}/to_note` | `owntracksMapToNote` |
 

--- a/mydiary-vuetify/src/api.ts
+++ b/mydiary-vuetify/src/api.ts
@@ -404,6 +404,8 @@ export type OwntracksDayMapImageParams = {
 tz?: string;
 width?: number;
 height?: number;
+fmt?: string;
+quality?: number;
 max_acc?: number;
 stay_radius_m?: number;
 stay_minutes?: number;
@@ -830,7 +832,7 @@ export const owntracksDayMapImage = (
     params?: OwntracksDayMapImageParams, options?: AxiosRequestConfig
  ): Promise<AxiosResponse<unknown | Blob>> => {
     return axios.get(
-      `/owntracks/map/${dt}.png`,{
+      `/owntracks/map/${dt}`,{
         responseType: 'blob',
     ...options,
         params: {...params, ...options?.params},}


### PR DESCRIPTION
Closes todo 4.4. The daily location map was saved as PNG, and every one of them lands in a diary note as a Joplin resource forever. A tile basemap is photographic, so PNG was paying for nothing — it only wins on flat colour and text, which here is just the footer strip.

Measured at the production 1200×900 on two real days:

| Encoding | 2026-07-01 | 2026-07-30 |
|---|---|---|
| PNG `optimize=True` (before) | 996 KB | 1290 KB |
| PNG, 64-colour palette | 367 KB | 500 KB |
| **JPEG q85, 4:4:4** | **219 KB** | **235 KB** |
| WebP q80 | 107 KB | 125 KB |

Side-by-side 1:1 crops of the footer legend and of street labels over the track were indistinguishable across all three. JPEG rather than the smaller WebP because these images exist to still open in thirty years. 1200×900 is unchanged — once the format changed, pixels stopped being the expensive part.

Two findings worth recording, since they close off options that looked promising:

- **`compress_level` is a dead end.** Pillow's `optimize=True` already implies level 9; 6 and 9 produce byte-identical output.
- **`subsampling=0` (4:4:4) is not the default and is load-bearing.** The track is thin saturated colour over a near-grey basemap, which is exactly what 4:2:0 chroma subsampling smears.

## How

Size and encoding move into a `RenderParams` frozen dataclass next to `TrackParams`, with the same `cache_key()` shape so the two compose. `render_for_day` folds both into the content hash:

    sha256(f"{track.content_hash(params)}|{render.cache_key()}")

composed there rather than in `owntracks_track.py`, which is documented as pure I/O-free track maths and should not learn about image encoding. This is the mechanism the whole change rides on: without the render params in the hash, every already-stored day would look up to date and be skipped.

`create_resource(ext=render.ext)` is the only other thing the note needs — Joplin derives the resource's mime type from that extension.

## Route change

`GET /owntracks/map/{dt}.png` → `GET /owntracks/map/{dt}`, since the format is now a query parameter (`fmt`, `quality`, alongside the existing `width`/`height`). An unknown `fmt` is a 400 rather than a 500 out of Pillow. The ETag drops its `-{width}x{height}` suffix now that the hash covers geometry and format on its own. `operation_id` is unchanged, and nothing in the frontend calls this route — `api.ts` is regenerated but no component changes.

## Backfill

`backend/scripts/owntracks_reencode_maps.py` re-encodes the maps already in Joplin, with `--start` / `--end` / `--limit` / `--dry-run`. It deliberately does **not** pass `force`: the new hash already differs for every un-migrated day, so the run does the work, and a day already migrated hashes equal and is skipped — which makes it resumable and safe to re-run.

**Already run against the live Joplin: 5 maps, 4.0 MB → 884 KB (78% smaller).** A second run reported all five as up to date. Merging this doesn't require running anything.

Note that it must run inside the backend container — `JOPLIN_BASE_URL` points at `host.docker.internal`, which doesn't resolve from the host.

## Drive-by fix

`_sync_day_map_to_note` tested `note_id is None`, but `get_note_id_by_date` returns the string `"does_not_exist"` — so a day with no Joplin note fell through into the Joplin calls and raised there, instead of the `LookupError` the backfill catches per day. Fixed, with a test.

## Testing

- Full backend suite: 209 passed. `test_renders_a_png_of_the_requested_size` flips to JPEG; a new case keeps `RenderParams(fmt="PNG")` covered. The footer pixel-probe test renders as PNG so it asserts what was drawn rather than how much JPEG nudged a flat colour.
- No byte-size regression assertion in the tests on purpose: `FakeTileDownloader` serves a flat single-colour tile, which PNG compresses to almost nothing, so PNG comes out *smaller* than JPEG on the fixture and such a test would encode the opposite of the truth.
- `npm run build` clean in the container.
- End to end: `GET /owntracks/map/2026-07-30` returns `image/jpeg` at 240 KB against 1321 KB for the same day as PNG; `to_note` returns `updated` then `no update`, proving the new hash is stable and not merely different; verified via the Joplin API that each note references its own `image/jpeg` resource with the itinerary intact, and that exactly 5 `map-*` resources exist with no orphaned PNGs left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
