### PR TITLE
owntracks: one map per distinct area, not one per day

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,3 +181,55 @@ Docker Compose overrides some of these to use paths inside the container (`token
 - `pendulum` is used throughout for date/time handling instead of stdlib `datetime`.
 - New database models go in `models.py`; connector logic stays in the corresponding `*_connector.py`.
 - Tests under `backend/tests/` use `pytest`. The `external_api` marker gates tests that hit live APIs.
+
+## This is a personal diary in a public repo
+
+The code is public; the diary is not. Nothing committed may contain real
+personal data, and location data is the easiest thing to leak by accident —
+a coordinate is a home address, and a date plus a city pair is an itinerary.
+
+**Never commit real location data.** Test fixtures and test cases use
+coordinates in open ocean, and that is deliberate, not arbitrary:
+
+- `backend/tests/owntracks_data/*.json` are anonymized to `~33.5, -42.0` with
+  `username: testuser`, `device: device-a`.
+- `test_owntracks_track.py` / `test_owntracks_maps.py` build cases from
+  `HOME_LAT/HOME_LON` (33.500, -42.005) and `FAR_LAT/FAR_LON` (26.782, -82.228),
+  ~3900km apart — far enough to exercise the multi-area map split.
+- Express new cases as offsets from those constants. 1° latitude is ~111km
+  anywhere; 1° longitude is ~93km at `HOME` and ~99km at `FAR`. Translating a
+  real day means keeping its *geometry*, not its coordinates.
+
+The same applies to prose. When a real day motivates a change, write down the
+shape of it and the measurement, not the trip:
+
+(The "don't" column below is written with invented places on purpose — a rule
+against recording itineraries should not record one as its own example.)
+
+| Don't | Do |
+|---|---|
+| "2026-03-14 (Springfield→Shelbyville)" | "a transcontinental flight day" |
+| "2026-03-14 was exactly this" | "one day in the data was exactly this" |
+| "its five Shelbyville stays" | "the five stays at the far end" |
+
+Aggregate statistics are fine and worth keeping — "318 days with a drawable
+track", "45 get more than one map" — they carry the engineering argument
+without pinning anyone anywhere. Real dates on their own are tolerated where
+they identify a fixture or a measurement; a date *paired with a place* is not.
+
+Also avoid baking a location into source as a default — e.g. a map's initial
+centre. `MapSection.vue` opens on a world view and refits to the day's track.
+
+Before committing, sweep the staged diff:
+
+```sh
+# any coordinate precise enough to be a real place
+git diff --cached | grep "^+" | grep -oE "\b[0-9]{1,2}\.[0-9]{4,}, ?-?[0-9]{1,3}\.[0-9]{4,}"
+# places you actually go — fill in the alternation yourself
+git diff --cached | grep "^+" | grep -inE "<place>|<place>|<place>"
+```
+
+The first is the one that catches accidents: anything with four or more decimal
+places is a real location, since the anonymized constants are quoted to three.
+The `public-readme-audit` skill covers the rest — secrets, credentials, PII,
+internal hostnames.

--- a/backend/alembic/versions/40e2fef86acd_owntracks_day_maps_one_row_per_map_panel.py
+++ b/backend/alembic/versions/40e2fef86acd_owntracks_day_maps_one_row_per_map_panel.py
@@ -1,0 +1,95 @@
+"""owntracks day maps: one row per map panel
+
+A day spent in two or more distinct areas gets several maps -- the whole-day
+overview plus one panel per area -- so diary_date alone can no longer be the
+primary key. Autogenerate only saw the added column: SQLite cannot alter a
+primary key in place, so the table is rebuilt by hand and existing rows become
+panel 0, the overview, which is what they already were.
+
+Revision ID: 40e2fef86acd
+Revises: fd9d21eb39d6
+Create Date: 2026-08-16 14:19:04.134461
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel.sql.sqltypes
+
+
+# revision identifiers, used by Alembic.
+revision: str = '40e2fef86acd'
+down_revision: Union[str, None] = 'fd9d21eb39d6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+COLUMNS = (
+    "diary_date",
+    "joplin_resource_id",
+    "content_hash",
+    "num_points",
+    "num_stays",
+    "distance_m",
+    "created_at",
+)
+
+
+def upgrade() -> None:
+    op.rename_table("owntracksdaymap", "owntracksdaymap_old")
+    op.create_table(
+        "owntracksdaymap",
+        sa.Column("diary_date", sa.Date(), nullable=False),
+        sa.Column("panel", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("joplin_resource_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("content_hash", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("num_points", sa.Integer(), nullable=False),
+        sa.Column("num_stays", sa.Integer(), nullable=False),
+        sa.Column("distance_m", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("diary_date", "panel", name="pk_owntracksdaymap"),
+    )
+    columns = ", ".join(COLUMNS)
+    op.execute(
+        f"INSERT INTO owntracksdaymap (panel, {columns}) "
+        f"SELECT 0, {columns} FROM owntracksdaymap_old"
+    )
+    # dropping the old table takes its copy of the index name with it, so the
+    # new index can only be created afterwards
+    op.drop_table("owntracksdaymap_old")
+    op.create_index(
+        op.f("ix_owntracksdaymap_content_hash"),
+        "owntracksdaymap",
+        ["content_hash"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.rename_table("owntracksdaymap", "owntracksdaymap_new")
+    op.create_table(
+        "owntracksdaymap",
+        sa.Column("diary_date", sa.Date(), nullable=False),
+        sa.Column("joplin_resource_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("content_hash", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("num_points", sa.Integer(), nullable=False),
+        sa.Column("num_stays", sa.Integer(), nullable=False),
+        sa.Column("distance_m", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("diary_date", name="pk_owntracksdaymap"),
+    )
+    columns = ", ".join(COLUMNS)
+    # the area panels have nowhere to go in a one-row-per-day table; only the
+    # overview survives, and the notes keep their now-unbookkept area images
+    op.execute(
+        f"INSERT INTO owntracksdaymap ({columns}) "
+        f"SELECT {columns} FROM owntracksdaymap_new WHERE panel = 0"
+    )
+    op.drop_table("owntracksdaymap_new")
+    op.create_index(
+        op.f("ix_owntracksdaymap_content_hash"),
+        "owntracksdaymap",
+        ["content_hash"],
+        unique=False,
+    )

--- a/backend/mydiary/api.py
+++ b/backend/mydiary/api.py
@@ -58,6 +58,10 @@ from .dictionary_connector import fetch_definition
 from .spotify_connector import normalize_spotify_id
 from .pocket_connector import MyDiaryPocket
 from .core import get_last_timezone
+
+# a route default, so it has to be resolved at import time rather than lazily
+# like the rest of the owntracks imports. owntracks_track is pure and cheap.
+from .owntracks_track import AREA_SPLIT_M
 from .mydiary_day import MyDiaryDay
 import uvicorn
 
@@ -864,6 +868,7 @@ def owntracks_locations_for_day(
 def owntracks_track_for_day(
     dt: str,
     tz: str = "infer",
+    area_threshold_m: float = AREA_SPLIT_M,
     max_acc: int = 100,
     stay_radius_m: float = 150.0,
     stay_minutes: float = 20.0,
@@ -874,11 +879,17 @@ def owntracks_track_for_day(
 ):
     """The processed day: stays and links, as GeoJSON.
 
-    The frontend map draws this, so the interactive view and the rendered PNG
-    always agree.
+    The frontend map draws this, so the interactive view and the rendered image
+    always agree -- including how many maps the day is in: every feature carries
+    the index of the area it belongs to, and `properties.areas` describes them.
     """
     from .owntracks_connector import MyDiaryOwnTracks
-    from .owntracks_track import build_track, points_from_locations, track_to_geojson
+    from .owntracks_track import (
+        build_track,
+        points_from_locations,
+        split_into_areas,
+        track_to_geojson,
+    )
 
     dt_obj = _owntracks_day(dt, tz, session)
     params = _track_params(
@@ -886,7 +897,8 @@ def owntracks_track_for_day(
     )
     locations = MyDiaryOwnTracks().get_locations_for_day(dt_obj, session=session)
     points = points_from_locations(locations, timezone=dt_obj.timezone_name)
-    return track_to_geojson(build_track(points, params))
+    track = build_track(points, params)
+    return track_to_geojson(track, split_into_areas(track, area_threshold_m))
 
 
 @app.get(
@@ -902,6 +914,7 @@ def owntracks_day_map_image(
     height: int = 900,
     fmt: str = "JPEG",
     quality: int = 85,
+    panel: int = 0,
     max_acc: int = 100,
     stay_radius_m: float = 150.0,
     stay_minutes: float = 20.0,
@@ -910,6 +923,8 @@ def owntracks_day_map_image(
     dwell_max_kmh: float = 1.0,
     session: Session = Depends(get_session),
 ):
+    """The day's map. Panel 0 is the whole day; on a day spent in two or more
+    distinct areas, higher panels are the per-area maps."""
     from .map_render import RenderParams
     from .owntracks_maps import render_for_day
 
@@ -923,7 +938,7 @@ def owntracks_day_map_image(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     try:
-        data, _, content_hash = render_for_day(dt_obj, session, params, render)
+        data, _, content_hash = render_for_day(dt_obj, session, params, render, panel)
     except LookupError as e:
         raise HTTPException(status_code=404, detail=str(e))
     # the content hash covers geometry and encoding on its own
@@ -935,6 +950,56 @@ def owntracks_day_map_image(
         media_type=media_type,
         headers={"ETag": etag, "Cache-Control": "private, max-age=3600"},
     )
+
+
+@app.get("/owntracks/areas/{dt}", operation_id="owntracksAreasForDay")
+def owntracks_areas_for_day(
+    dt: str,
+    tz: str = "infer",
+    area_threshold_m: float = AREA_SPLIT_M,
+    max_acc: int = 100,
+    stay_radius_m: float = 150.0,
+    stay_minutes: float = 20.0,
+    gap_minutes: float = 45.0,
+    gap_metres: float = 250.0,
+    dwell_max_kmh: float = 1.0,
+    session: Session = Depends(get_session),
+):
+    """The parts of the day worth framing separately, empty when one map fits.
+
+    Clustering runs on stays only: a road trip's waypoints are each far apart,
+    so clustering every point would report a single drive as dozens of areas.
+    """
+    from .owntracks_maps import day_track
+    from .owntracks_track import split_into_areas
+
+    dt_obj = _owntracks_day(dt, tz, session)
+    params = _track_params(
+        max_acc, stay_radius_m, stay_minutes, gap_minutes, gap_metres, dwell_max_kmh
+    )
+    try:
+        track = day_track(dt_obj, session, params)
+    except LookupError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    areas = split_into_areas(track, area_threshold_m)
+    return {
+        "num_areas": len(areas),
+        # the whole-day overview counts too, so a two-area day is three maps
+        "num_maps": 1 + len(areas),
+        "areas": [
+            {
+                "index": i,
+                "label": area.label(),
+                "t_start": area.t_start.isoformat(),
+                "t_end": area.t_end.isoformat(),
+                "num_stays": len(area.track.stays),
+                "distance_m": round(area.track.distance_m),
+                # the frame, not the contents: what the panel is fitted to
+                "bounds": area.frame.bounds(),
+            }
+            for i, area in enumerate(areas)
+        ],
+    }
 
 
 @app.post("/owntracks/sync", operation_id="owntracksSyncLocations")
@@ -957,17 +1022,17 @@ def owntracks_map_to_note(
     session: Session = Depends(get_session),
     mydiary_joplin: MyDiaryJoplin = Depends(get_joplin_client),
 ):
-    """Render the day's map and write it into the note's Location section."""
+    """Render the day's map(s) and write them into the note's Location section."""
     from .owntracks_maps import sync_day_map_to_note
 
     dt_obj = _owntracks_day(dt, tz, session)
     try:
-        result = sync_day_map_to_note(
+        result, num_maps = sync_day_map_to_note(
             dt_obj, session=session, mydiary_joplin=mydiary_joplin, force=force
         )
     except LookupError as e:
         raise HTTPException(status_code=404, detail=str(e))
-    return {"result": result}
+    return {"result": result, "num_maps": num_maps}
 
 
 @app.post(

--- a/backend/mydiary/map_render.py
+++ b/backend/mydiary/map_render.py
@@ -156,15 +156,28 @@ def _font(size: int) -> ImageFont.ImageFont:
 
 
 class TrackOverlay(staticmaps.Object):
-    """Draws the day onto the map, in map pixel space."""
+    """Draws the day onto the map, in map pixel space.
 
-    def __init__(self, track: DayTrack, scale: int = SUPERSAMPLE) -> None:
+    What is drawn and what the map is framed on are two different things: an
+    area panel is framed on the places it stopped, and the leg leaving for
+    somewhere else is still drawn, running off the edge. Framing on the contents
+    instead would zoom back out to include that leg, which is the whole thing
+    the panel exists to avoid.
+    """
+
+    def __init__(
+        self,
+        track: DayTrack,
+        scale: int = SUPERSAMPLE,
+        frame: Optional[DayTrack] = None,
+    ) -> None:
         super().__init__()
         self.track = track
         self.scale = scale
+        self.frame = frame if frame is not None else track
 
     def bounds(self) -> s2sphere.LatLngRect:
-        return bounds_for(self.track)
+        return bounds_for(self.frame)
 
     def extra_pixel_bounds(self):
         # keep the biggest dwell circle from being clipped at the edge
@@ -436,13 +449,21 @@ def render_day_map(
     params: Optional[TrackParams] = None,
     render: Optional[RenderParams] = None,
     tile_downloader=None,
+    frame: Optional[DayTrack] = None,
 ) -> bytes:
     """Render a day's track to encoded image bytes.
+
+    frame is what the map is fitted and cropped to, if that should be less than
+    everything drawn -- an area panel frames on its stays so that the leg out of
+    the area does not drag the zoom back to the whole journey. Defaults to the
+    track itself.
 
     tile_downloader is only for tests; leaving it None uses the real, cached one.
     """
     if track.is_empty():
         raise ValueError("cannot render a map for a day with no location data")
+    if frame is not None and frame.is_empty():
+        frame = None
 
     render = render or RenderParams()
     width, height = render.width, render.height
@@ -460,8 +481,10 @@ def render_day_map(
     ctx.set_tile_downloader(downloader)
     ctx.set_background_color(staticmaps.parse_color("#fafaf9"))
 
-    overlay = TrackOverlay(track, scale=SUPERSAMPLE)
-    ctx.add_bounds(bounds_for(track), extra_pixel_bounds=overlay.extra_pixel_bounds())
+    overlay = TrackOverlay(track, scale=SUPERSAMPLE, frame=frame)
+    ctx.add_bounds(
+        bounds_for(overlay.frame), extra_pixel_bounds=overlay.extra_pixel_bounds()
+    )
     ctx.add_object(overlay)
     labels = LabelsOverlay(cache_dir)
     if tile_downloader is not None:
@@ -470,7 +493,7 @@ def render_day_map(
 
     render_w, render_h = width * SUPERSAMPLE, map_height * SUPERSAMPLE
     rendered = ctx.render_pillow(render_w, render_h)
-    box = _crop_box(ctx, track, render_w, render_h, width / map_height)
+    box = _crop_box(ctx, overlay.frame, render_w, render_h, width / map_height)
     if box is not None:
         rendered = rendered.crop(box)
     rendered = rendered.convert("RGB").resize((width, map_height), Image.LANCZOS)

--- a/backend/mydiary/models.py
+++ b/backend/mydiary/models.py
@@ -686,8 +686,11 @@ class OwnTracksDayMap(SQLModel, table=True):
     # bookkeeping for the rendered daily map, so that re-rendering an unchanged
     # day reuses its Joplin resource instead of orphaning one
     diary_date: date = Field(primary_key=True)
+    # 0 is the whole-day overview, and on most days the only map there is; a day
+    # spent in two or more distinct areas adds a tighter panel per area
+    panel: int = Field(default=0, primary_key=True)
     joplin_resource_id: str
-    # sha256 over the processed track plus the render params
+    # sha256 over this panel's track plus the render params
     content_hash: str = Field(index=True)
     num_points: int
     num_stays: int

--- a/backend/mydiary/mydiary_day.py
+++ b/backend/mydiary/mydiary_day.py
@@ -58,7 +58,9 @@ class MyDiaryDay:
         owntracks_locations: List[
             OwnTracksLocation
         ] = [],  # location fixes recorded on this day
-        owntracks_day_map: Optional[OwnTracksDayMap] = None,
+        owntracks_day_maps: List[
+            OwnTracksDayMap
+        ] = [],  # the day's rendered maps, ordered by panel
         rating: Optional[
             int
         ] = None,  # (emotional) rating for the day. should it be an enum? should it also include a text description (and be its own object type)?
@@ -76,7 +78,7 @@ class MyDiaryDay:
         self.pocket_articles = pocket_articles
         self.google_calendar_events = google_calendar_events
         self.owntracks_locations = owntracks_locations
-        self.owntracks_day_map = owntracks_day_map
+        self.owntracks_day_maps = owntracks_day_maps
         self.rating = rating
         self.flagged = flagged
 
@@ -152,7 +154,13 @@ class MyDiaryDay:
         owntracks_locations = mydiary_owntracks.get_locations_for_day(
             dt, session=session
         )
-        owntracks_day_map = session.get(OwnTracksDayMap, dt.date())
+        owntracks_day_maps = list(
+            session.exec(
+                select(OwnTracksDayMap)
+                .where(OwnTracksDayMap.diary_date == dt.date())
+                .order_by(OwnTracksDayMap.panel)
+            )
+        )
 
         return cls(
             dt=dt,
@@ -162,7 +170,7 @@ class MyDiaryDay:
             spotify_tracks=spotify_tracks,
             google_calendar_events=google_calendar_events,
             owntracks_locations=owntracks_locations,
-            owntracks_day_map=owntracks_day_map,
+            owntracks_day_maps=owntracks_day_maps,
             joplin_note_id=getattr(note, "id", None),
             **kwargs,
         )
@@ -231,15 +239,21 @@ class MyDiaryDay:
 
     def owntracks_markdown(self) -> str:
         # lazily imported: owntracks_maps imports this module
-        from .owntracks_maps import section_content
+        from .owntracks_maps import panels_for_track, section_content
 
         if not self.owntracks_locations:
             return "None"
         track = self.build_owntracks_track()
         if track.is_empty():
             return "None"
-        resource_id = getattr(self.owntracks_day_map, "joplin_resource_id", None)
-        return section_content(resource_id, track)
+        # re-derive the panels rather than trusting the stored row count: a day
+        # that has already been split into areas must not be flattened back to
+        # one map here, or sync_day_map_to_note would see an unchanged hash and
+        # leave the note that way
+        panels = panels_for_track(track)
+        by_panel = {m.panel: m.joplin_resource_id for m in self.owntracks_day_maps}
+        resource_ids = [by_panel.get(i) for i in range(len(panels))]
+        return section_content(resource_ids, panels)
 
     def spotify_tracks_markdown(self, timezone=None) -> str:
         if not self.spotify_tracks:

--- a/backend/mydiary/owntracks_maps.py
+++ b/backend/mydiary/owntracks_maps.py
@@ -8,8 +8,9 @@ own bookkeeping table. That table exists so a re-render of an unchanged day
 reuses its Joplin resource rather than orphaning one."""
 
 import hashlib
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional, Tuple
+from typing import List, Optional, Sequence, Tuple
 
 import pendulum
 from sqlmodel import Session, select
@@ -21,7 +22,7 @@ from .markdown_edits import MarkdownDoc
 from .models import OwnTracksDayMap
 from .mydiary_day import MyDiaryDay
 from .owntracks_connector import MyDiaryOwnTracks
-from .owntracks_track import DayTrack, TrackParams
+from .owntracks_track import AREA_SPLIT_M, DayTrack, TrackParams, split_into_areas
 
 import logging
 
@@ -33,28 +34,34 @@ SECTION_TITLE = "Location"
 SECTION_AFTER = "Images"
 
 
-def render_for_day(
-    dt: datetime,
-    session: Session,
-    params: Optional[TrackParams] = None,
-    render: Optional[RenderParams] = None,
-) -> Tuple[bytes, DayTrack, str]:
-    """Render the map for a day. Returns (image bytes, track, content_hash).
+@dataclass(frozen=True)
+class Panel:
+    """One map that ends up in the note.
 
-    The hash covers the render parameters as well as the track, so changing the
-    size or the encoding invalidates a stored map the same way new location
-    data does. It is composed here rather than in owntracks_track, which is
-    pure track maths and has no business knowing about image encoding.
+    Panel 0 is always the whole-day overview -- on most days the only map there
+    is. A day split across distinct areas keeps that overview (on a flight day
+    "I went from here to there" is real information) and adds a panel per area,
+    framed tightly enough to actually read.
     """
-    params = params or TrackParams()
-    render = render or RenderParams()
-    mydiary_owntracks = MyDiaryOwnTracks()
-    locations = mydiary_owntracks.get_locations_for_day(dt, session=session)
-    if not locations:
-        raise LookupError(f"no location data for {pendulum.instance(dt).to_date_string()}")
+
+    kind: str  # "overview" | "area"
+    label: str  # "" for the overview, "08:12-11:40" for an area
+    track: DayTrack  # what gets drawn
+    frame: Optional[DayTrack]  # what it is framed on; None means the whole track
+    content_hash: str
+
+
+def day_track(
+    dt: datetime, session: Session, params: Optional[TrackParams] = None
+) -> DayTrack:
+    """The day's processed track, or LookupError if there is nothing to draw."""
     from .owntracks_track import build_track, points_from_locations
 
+    params = params or TrackParams()
     dt = pendulum.instance(dt)
+    locations = MyDiaryOwnTracks().get_locations_for_day(dt, session=session)
+    if not locations:
+        raise LookupError(f"no location data for {dt.to_date_string()}")
     track = build_track(
         points_from_locations(locations, timezone=dt.timezone_name), params
     )
@@ -63,11 +70,106 @@ def render_for_day(
             f"no usable location data for {dt.to_date_string()} "
             f"({len(locations)} fixes, all filtered out)"
         )
-    data = render_day_map(track, params, render)
-    content_hash = hashlib.sha256(
-        f"{track.content_hash(params)}|{render.cache_key()}".encode()
-    ).hexdigest()
-    return data, track, content_hash
+    return track
+
+
+def _content_hash(
+    track: DayTrack, params: TrackParams, render: RenderParams, suffix: str = ""
+) -> str:
+    """Digest of what a panel will look like, for resource reuse.
+
+    Covers the render parameters as well as the track, so changing the size or
+    the encoding invalidates a stored map the same way new location data does.
+    Composed here rather than in owntracks_track, which is pure track maths and
+    has no business knowing about image encoding.
+    """
+    key = f"{track.content_hash(params)}|{render.cache_key()}"
+    if suffix:
+        key = f"{key}|{suffix}"
+    return hashlib.sha256(key.encode()).hexdigest()
+
+
+def panels_for_track(
+    track: DayTrack,
+    params: Optional[TrackParams] = None,
+    render: Optional[RenderParams] = None,
+    area_threshold_m: float = AREA_SPLIT_M,
+) -> List[Panel]:
+    """The maps a track needs: the overview, plus one per distinct area.
+
+    A one-area day gets one panel, and that panel's track *is* the whole day --
+    so it hashes to exactly what a day map hashed to before panels existed, and
+    no already-synced day is invalidated by this. The same holds for the
+    overview panel of a multi-area day, whose resource is therefore reused.
+    """
+    params = params or TrackParams()
+    render = render or RenderParams()
+    panels = [
+        Panel("overview", "", track, None, _content_hash(track, params, render))
+    ]
+    # empty on a day one frame already fits, which is most of them
+    panels.extend(
+        Panel(
+            "area",
+            area.label(),
+            area.track,
+            area.frame,
+            _content_hash(area.track, params, render, _area_key(i, area)),
+        )
+        for i, area in enumerate(split_into_areas(track, area_threshold_m))
+    )
+    return panels
+
+
+def _area_key(i: int, area) -> str:
+    """What distinguishes this panel from the same content drawn differently.
+
+    The index keeps two identical-looking areas apart, and the frame is in here
+    because it decides the zoom: change how panels are framed and every stored
+    area panel has to know it is stale, or a re-sync reports no update and
+    leaves the old picture in the note.
+    """
+    b = area.frame.bounds()
+    frame = "none" if b is None else ",".join(f"{x:.6f}" for x in b)
+    return f"area{i}|frame={frame}"
+
+
+def panels_for_day(
+    dt: datetime,
+    session: Session,
+    params: Optional[TrackParams] = None,
+    render: Optional[RenderParams] = None,
+    area_threshold_m: float = AREA_SPLIT_M,
+) -> Tuple[DayTrack, List[Panel]]:
+    """panels_for_track, for a day that has to be loaded from the database."""
+    params = params or TrackParams()
+    track = day_track(dt, session, params)
+    return track, panels_for_track(track, params, render, area_threshold_m)
+
+
+def render_for_day(
+    dt: datetime,
+    session: Session,
+    params: Optional[TrackParams] = None,
+    render: Optional[RenderParams] = None,
+    panel: int = 0,
+) -> Tuple[bytes, DayTrack, str]:
+    """Render one of the day's maps. Returns (image bytes, track, content_hash).
+
+    Panel 0 is the whole-day overview; higher indices select an area panel on a
+    day that has more than one area.
+    """
+    params = params or TrackParams()
+    render = render or RenderParams()
+    _, panels = panels_for_day(dt, session, params, render)
+    if not 0 <= panel < len(panels):
+        raise LookupError(
+            f"{pendulum.instance(dt).to_date_string()} has {len(panels)} map"
+            f"{'' if len(panels) == 1 else 's'}, so there is no panel {panel}"
+        )
+    chosen = panels[panel]
+    data = render_day_map(chosen.track, params, render, frame=chosen.frame)
+    return data, chosen.track, chosen.content_hash
 
 
 def sync_day_map_to_note(
@@ -77,11 +179,12 @@ def sync_day_map_to_note(
     params: Optional[TrackParams] = None,
     force: bool = False,
     render: Optional[RenderParams] = None,
-) -> str:
-    """Render the day's map, upload it to Joplin, and write the Location section.
+) -> Tuple[str, int]:
+    """Render the day's map(s), upload to Joplin, and write the Location section.
 
-    Re-running for an unchanged day is a no-op: the content hash covers both the
-    processed track and the render parameters.
+    Returns (result, number of maps written). Re-running for an unchanged day is
+    a no-op: the content hash covers both the processed track and the render
+    parameters.
     """
     close_session = session is None
     if session is None:
@@ -106,80 +209,140 @@ def _sync_day_map_to_note(
     params: Optional[TrackParams],
     force: bool,
     render: Optional[RenderParams] = None,
-) -> str:
+) -> Tuple[str, int]:
     dt = pendulum.instance(dt)
     diary_date = dt.date()
+    params = params or TrackParams()
     render = render or RenderParams()
-    data, track, content_hash = render_for_day(dt, session, params, render)
+    _, panels = panels_for_day(dt, session, params, render)
 
-    existing = session.get(OwnTracksDayMap, diary_date)
+    existing = list(
+        session.exec(
+            select(OwnTracksDayMap)
+            .where(OwnTracksDayMap.diary_date == diary_date)
+            .order_by(OwnTracksDayMap.panel)
+        )
+    )
     if (
-        existing is not None
-        and existing.content_hash == content_hash
-        and not force
-        and mydiary_joplin.resource_exists(existing.joplin_resource_id)
+        not force
+        and [row.content_hash for row in existing] == [p.content_hash for p in panels]
+        and all(
+            mydiary_joplin.resource_exists(row.joplin_resource_id) for row in existing
+        )
     ):
         logger.info(f"owntracks map for {diary_date} is already up to date")
-        return "no update"
+        return "no update", len(panels)
 
     note_id = mydiary_joplin.get_note_id_by_date(dt)
     if note_id is None or note_id == "does_not_exist":
         raise LookupError(f"no Joplin note for {diary_date}")
 
-    # Joplin takes the resource's mime from this extension, so it is the only
-    # thing the note needs in order to render a non-PNG map
-    r = mydiary_joplin.create_resource(
-        data=data, title=f"map-{diary_date}", ext=render.ext
+    # an unchanged panel keeps its resource, so a day that gains areas re-uploads
+    # only the new panels and leaves its overview alone
+    reusable = (
+        {}
+        if force
+        else {
+            row.content_hash: row.joplin_resource_id
+            for row in existing
+            if mydiary_joplin.resource_exists(row.joplin_resource_id)
+        }
     )
-    r.raise_for_status()
-    resource_id = r.json()["id"]
+    old_resource_ids = [row.joplin_resource_id for row in existing]
 
-    old_resource_id = existing.joplin_resource_id if existing is not None else None
+    resource_ids: List[str] = []
+    created: List[str] = []
     try:
+        for i, panel in enumerate(panels):
+            resource_id = reusable.get(panel.content_hash)
+            if resource_id is None:
+                data = render_day_map(
+                    panel.track, params, render, frame=panel.frame
+                )
+                # Joplin takes the resource's mime from this extension, so it is
+                # the only thing the note needs to render a non-PNG map
+                title = f"map-{diary_date}" if i == 0 else f"map-{diary_date}-{i}"
+                r = mydiary_joplin.create_resource(
+                    data=data, title=title, ext=render.ext
+                )
+                r.raise_for_status()
+                resource_id = r.json()["id"]
+                created.append(resource_id)
+            resource_ids.append(resource_id)
+
         note = mydiary_joplin.get_note(note_id)
         md_note = MarkdownDoc(note.body, parent=note)
         # an old note predating this feature has no Location section at all, and
         # update_joplin_note will never add one
         section = md_note.ensure_section(SECTION_TITLE, after_title=SECTION_AFTER)
-        section.set_content(section_content(resource_id, track))
+        section.set_content(section_content(resource_ids, panels))
         response = mydiary_joplin.update_note_body(note_id, md_note.txt)
         response.raise_for_status()
 
-        session.merge(
-            OwnTracksDayMap(
-                diary_date=diary_date,
-                joplin_resource_id=resource_id,
-                content_hash=content_hash,
-                num_points=track.num_points,
-                num_stays=len(track.stays),
-                distance_m=int(track.distance_m),
-                created_at=pendulum.now(tz="UTC"),
+        for i, (panel, resource_id) in enumerate(zip(panels, resource_ids)):
+            session.merge(
+                OwnTracksDayMap(
+                    diary_date=diary_date,
+                    panel=i,
+                    joplin_resource_id=resource_id,
+                    content_hash=panel.content_hash,
+                    num_points=panel.track.num_points,
+                    num_stays=len(panel.track.stays),
+                    distance_m=int(panel.track.distance_m),
+                    created_at=pendulum.now(tz="UTC"),
+                )
             )
-        )
+        # a day that lost an area leaves rows behind that nothing points at
+        for row in existing:
+            if row.panel >= len(panels):
+                session.delete(row)
         session.commit()
     except Exception:
         session.rollback()
+        for resource_id in created:
+            try:
+                mydiary_joplin.delete_resource(resource_id, force=True)
+            except Exception:
+                logger.warning(f"failed to clean up joplin resource {resource_id}")
+        raise
+
+    # the note now points at the new resources, so superseded ones are safe to drop
+    for resource_id in old_resource_ids:
+        if resource_id in resource_ids:
+            continue
         try:
             mydiary_joplin.delete_resource(resource_id, force=True)
         except Exception:
-            logger.warning(f"failed to clean up joplin resource {resource_id}")
-        raise
-
-    # the note now points at the new resource, so the old one is safe to drop
-    if old_resource_id and old_resource_id != resource_id:
-        try:
-            mydiary_joplin.delete_resource(old_resource_id, force=True)
-        except Exception:
-            logger.warning(f"failed to delete superseded resource {old_resource_id}")
-    return "updated"
+            logger.warning(f"failed to delete superseded resource {resource_id}")
+    return "updated", len(panels)
 
 
-def section_content(resource_id: Optional[str], track: DayTrack) -> str:
-    """The Location section body: the map, then a searchable itinerary.
+def section_content(
+    resource_ids: Sequence[Optional[str]], panels: Sequence[Panel]
+) -> str:
+    """The Location section body: the map(s), then a searchable itinerary.
 
     The itinerary is the part that keeps working -- Joplin can search text, but
     it cannot search an image.
+
+    One panel is the common case and emits exactly what it always has. A day
+    split across areas leads with the whole-day overview, then gives each area
+    its own heading, map and itinerary -- the day-level table would only repeat
+    what the per-area ones say, since every stay belongs to exactly one area.
     """
+    if len(panels) == 1:
+        return _panel_content(resource_ids[0], panels[0].track)
+
+    parts = [_panel_content(resource_ids[0], panels[0].track, itinerary=False)]
+    for resource_id, panel in zip(resource_ids[1:], panels[1:]):
+        # level 3, so MarkdownDoc (which splits on "## ") keeps this one section
+        parts.append(f"### {panel.label}\n\n{_panel_content(resource_id, panel.track)}")
+    return "\n\n".join(parts)
+
+
+def _panel_content(
+    resource_id: Optional[str], track: DayTrack, itinerary: bool = True
+) -> str:
     from .owntracks_track import summary_label
     from .models import make_markdown_table_header
 
@@ -187,7 +350,7 @@ def section_content(resource_id: Optional[str], track: DayTrack) -> str:
     if resource_id:
         lines.extend([f"![](:/{resource_id})", ""])
     lines.append(summary_label(track))
-    if track.stays:
+    if itinerary and track.stays:
         lines.append("")
         lines.append(make_markdown_table_header(["Arrive", "Depart", "Duration", "Where"]))
         for stay in track.stays:

--- a/backend/mydiary/owntracks_track.py
+++ b/backend/mydiary/owntracks_track.py
@@ -61,6 +61,20 @@ class TrackParams:
         )
 
 
+# stays farther apart than this are different places, not one sprawling one.
+# deliberately NOT a TrackParams field: cache_key() feeds the stored content
+# hash, so adding a field there would invalidate every day in the database and
+# rewrite every note on the next sync.
+AREA_SPLIT_M = 20_000.0
+
+# ...and an area only earns a panel of its own by framing at least this much
+# tighter than the whole-day map. Separation alone is not enough: an area can
+# hold a link almost as long as the day itself, and then its "closer" panel is
+# the same picture again. Measured over 318 days, the ratios fall in two groups
+# with nothing between 0.45 and 0.62, so the exact number here is not delicate.
+FRAME_GAIN = 0.5
+
+
 @dataclass(frozen=True)
 class Period:
     name: str
@@ -461,8 +475,198 @@ def build_track(
     )
 
 
-def track_to_geojson(track: DayTrack) -> dict:
-    """FeatureCollection for the frontend map -- same pipeline as the PNG."""
+@dataclass(frozen=True)
+class Area:
+    """One geographically distinct part of a day.
+
+    track holds the area's stays and the links that fall entirely inside it. A
+    link between two areas belongs to neither -- it is what connects them, and
+    drawing a flight on the panel at either end is 4000km of nothing.
+
+    frame is what the panel is fitted to: the stays, not the contents. An area
+    can hold a leg 16km long, and framing on that would zoom back out until the
+    panel is the overview again -- which is exactly what a panel is for avoiding.
+    The leg is still drawn; it just runs off the edge, which reads correctly as
+    leaving.
+    """
+
+    track: DayTrack
+    t_start: datetime
+    t_end: datetime
+
+    @property
+    def frame(self) -> DayTrack:
+        return DayTrack(stays=self.track.stays)
+
+    def label(self) -> str:
+        """e.g. '08:12–11:40'. First arrival to last departure, so a day that
+        leaves and comes back reports the span; the itinerary below it in the
+        note is what shows the separate visits."""
+        return f"{self.t_start:%H:%M}–{self.t_end:%H:%M}"
+
+
+def cluster_stays(
+    stays: Sequence[Stay], threshold_m: float = AREA_SPLIT_M
+) -> List[List[Stay]]:
+    """Group stays by single linkage: within threshold_m of *any* member.
+
+    Single rather than complete linkage on purpose -- a city is a chain of
+    places you were, and two ends of it being 25km apart does not make them two
+    areas as long as something sits between them.
+    """
+    clusters: List[List[Stay]] = []
+    for stay in stays:
+        joined = [
+            i
+            for i, cluster in enumerate(clusters)
+            if any(
+                haversine_m(stay.lat, stay.lon, other.lat, other.lon) <= threshold_m
+                for other in cluster
+            )
+        ]
+        if not joined:
+            clusters.append([stay])
+            continue
+        first = joined[0]
+        clusters[first].append(stay)
+        # this stay may be the bridge between clusters that were separate
+        for i in reversed(joined[1:]):
+            clusters[first].extend(clusters.pop(i))
+    return clusters
+
+
+def _nearest_cluster(
+    lat: float, lon: float, clusters: Sequence[Sequence[Stay]], threshold_m: float
+) -> Optional[int]:
+    """Index of the cluster this position belongs to, or None if it is between
+    them (in transit)."""
+    best_i: Optional[int] = None
+    best_d = math.inf
+    for i, cluster in enumerate(clusters):
+        d = min(haversine_m(lat, lon, s.lat, s.lon) for s in cluster)
+        if d < best_d:
+            best_i, best_d = i, d
+    return best_i if best_d <= threshold_m else None
+
+
+def extent_m(track: DayTrack) -> float:
+    """How wide the track is on the ground, in metres.
+
+    The longer side of its bounding box, which is what the fitted zoom -- and so
+    how much detail survives -- actually follows.
+    """
+    b = track.bounds()
+    if b is None:
+        return 0.0
+    min_lat, min_lon, max_lat, max_lon = b
+    return max(
+        haversine_m(min_lat, min_lon, max_lat, min_lon),
+        haversine_m(min_lat, min_lon, min_lat, max_lon),
+    )
+
+
+def _track_span(track: DayTrack) -> Optional[Tuple[datetime, datetime]]:
+    starts = [s.t_start for s in track.stays] + [x.t_start for x in track.links]
+    ends = [s.t_end for s in track.stays] + [x.t_end for x in track.links]
+    if not starts:
+        return None
+    return min(starts), max(ends)
+
+
+def split_into_areas(
+    track: DayTrack, threshold_m: float = AREA_SPLIT_M
+) -> List[Area]:
+    """The parts of a day worth framing separately, in time order.
+
+    Returns **empty** when one frame already fits the day -- there is a single
+    area and nothing drawn reaches outside it -- which is the common case and
+    means "one map, exactly as before".
+
+    Clustering runs on **stays only**. Clustering all points instead counts a
+    chain as a crowd: consecutive waypoints along a road trip are each far apart,
+    so a single drive decomposes into dozens of spurious areas. A "distinct area"
+    has to mean somewhere you actually were, not somewhere you passed.
+
+    But the count of areas is not on its own what decides whether a day needs
+    more than one map. A flight day can have all its stays at one end -- leaving
+    home, the airport and the flight are all transit, and none of them dwells --
+    so it is one area sitting inside a 4000km frame. What matters is whether the
+    overview frames the areas or dwarfs them, so a single area still gets its own
+    panel once something drawn reaches more than threshold_m outside it.
+
+    That test is about the day reaching outside an area, which is not the same
+    as the area being small: an area can hold a link almost as long as the day
+    itself, and then its panel is the overview again at a slightly closer zoom.
+    So the areas are only kept if at least one of them frames FRAME_GAIN tighter
+    than the whole day.
+    """
+    if _track_span(track) is None:
+        return []
+    clusters = cluster_stays(track.stays, threshold_m)
+    if not clusters:
+        return []  # pure transit: nowhere to frame more tightly than the day
+
+    clusters.sort(key=lambda c: min(s.t_start for s in c))
+    ends = [
+        (
+            _nearest_cluster(link.start_lat, link.start_lon, clusters, threshold_m),
+            _nearest_cluster(link.end_lat, link.end_lon, clusters, threshold_m),
+        )
+        for link in track.links
+    ]
+    reaches_outside = any(a is None or b is None for a, b in ends)
+    if len(clusters) == 1 and not reaches_outside:
+        return []
+
+    areas: List[Area] = []
+    for i, cluster in enumerate(clusters):
+        stays = sorted(cluster, key=lambda s: s.t_start)
+        links = [
+            link
+            for link, (a, b) in zip(track.links, ends)
+            if a == i and b == i
+        ]
+        areas.append(
+            Area(
+                track=DayTrack(
+                    stays=stays,
+                    links=links,
+                    num_points=sum(s.num_points for s in stays),
+                    # dropped fixes are a fact about the day, not about one area;
+                    # repeating the count in every panel footer would multiply it
+                    num_dropped=0,
+                    distance_m=sum(link.distance_m for link in links),
+                ),
+                t_start=stays[0].t_start,
+                t_end=max(s.t_end for s in stays),
+            )
+        )
+
+    # all or nothing, so every stay stays covered by exactly one itinerary: if
+    # not even the tightest area frames meaningfully closer than the overview,
+    # the extra panels are the same picture again and the day wants one map.
+    day_extent = extent_m(track)
+    if day_extent and min(extent_m(a.frame) for a in areas) > FRAME_GAIN * day_extent:
+        return []
+    return areas
+
+
+def track_to_geojson(
+    track: DayTrack, areas: Optional[Sequence[Area]] = None
+) -> dict:
+    """FeatureCollection for the frontend map -- same pipeline as the image.
+
+    Pass the day's areas and every feature carries the index of the area it
+    belongs to (None for a link between two of them), and the collection carries
+    the areas themselves. That is what lets the frontend draw the same set of
+    maps the note gets, rather than one map of everything.
+    """
+    area_of = {}
+    for i, area in enumerate(areas or []):
+        for stay in area.track.stays:
+            area_of[stay] = i
+        for link in area.track.links:
+            area_of[link] = i
     features = []
     for link in track.links:
         features.append(
@@ -477,6 +681,7 @@ def track_to_geojson(track: DayTrack) -> dict:
                 },
                 "properties": {
                     "kind": "link",
+                    "area": area_of.get(link),
                     "uncertain": link.uncertain,
                     "period": link.period.name,
                     "color": link.period.color,
@@ -493,6 +698,7 @@ def track_to_geojson(track: DayTrack) -> dict:
                 "geometry": {"type": "Point", "coordinates": [stay.lon, stay.lat]},
                 "properties": {
                     "kind": "stay",
+                    "area": area_of.get(stay),
                     "period": stay.period.name,
                     "color": stay.period.color,
                     "t_start": stay.t_start.isoformat(),
@@ -511,6 +717,21 @@ def track_to_geojson(track: DayTrack) -> dict:
             "num_dropped": track.num_dropped,
             "num_stays": len(track.stays),
             "distance_m": round(track.distance_m),
+            # the overview counts too, so two areas means three maps
+            "num_maps": 1 + len(areas or []),
+            "areas": [
+                {
+                    "index": i,
+                    "label": area.label(),
+                    "t_start": area.t_start.isoformat(),
+                    "t_end": area.t_end.isoformat(),
+                    "num_stays": len(area.track.stays),
+                    "distance_m": round(area.track.distance_m),
+                    # the frame, not the contents: what the panel is fitted to
+                    "bounds": area.frame.bounds(),
+                }
+                for i, area in enumerate(areas or [])
+            ],
         },
     }
 

--- a/backend/scripts/owntracks_reencode_maps.py
+++ b/backend/scripts/owntracks_reencode_maps.py
@@ -60,7 +60,17 @@ def start_of_day(diary_date, session: Session) -> pendulum.DateTime:
 
 def main(args):
     with Session(engine) as session, MyDiaryJoplin(init_config=False) as mydiary_joplin:
-        stmt = select(OwnTracksDayMap).order_by(OwnTracksDayMap.diary_date)
+        # this selects the *days* to visit, not the maps to re-encode: one
+        # sync_day_map_to_note re-renders every panel the day has. A day can now
+        # hold several map rows, so filtering to panel 0 -- the overview, the one
+        # row every day has -- is what keeps that one visit per day instead of
+        # one per panel. The sizes reported below are the overview's, so they
+        # stay comparable run to run.
+        stmt = (
+            select(OwnTracksDayMap)
+            .where(OwnTracksDayMap.panel == 0)
+            .order_by(OwnTracksDayMap.diary_date)
+        )
         if args.start:
             stmt = stmt.where(
                 OwnTracksDayMap.diary_date >= pendulum.parse(args.start).date()
@@ -93,7 +103,7 @@ def main(args):
                         continue
                     after = len(data)
                 else:
-                    result = sync_day_map_to_note(
+                    result, _ = sync_day_map_to_note(
                         dt, session=session, mydiary_joplin=mydiary_joplin
                     )
                     if result == "no update":

--- a/backend/tests/test_owntracks_maps.py
+++ b/backend/tests/test_owntracks_maps.py
@@ -11,7 +11,12 @@ from mydiary import owntracks_maps
 from mydiary.map_render import RenderParams
 from mydiary.markdown_edits import MarkdownDoc
 from mydiary.models import JoplinNote, OwnTracksDayMap, OwnTracksLocation
-from mydiary.owntracks_maps import render_for_day, section_content, sync_day_map_to_note
+from mydiary.owntracks_maps import (
+    panels_for_track,
+    render_for_day,
+    section_content,
+    sync_day_map_to_note,
+)
 
 TZ = "America/New_York"
 DAY = "2026-07-01"
@@ -109,9 +114,9 @@ def offline_tiles(monkeypatch):
     """Render without the network."""
     real_render = owntracks_maps.render_day_map
 
-    def _render(track, params=None, render=None, tile_downloader=None):
+    def _render(track, params=None, render=None, tile_downloader=None, frame=None):
         return real_render(
-            track, params, render, tile_downloader=FakeTileDownloader()
+            track, params, render, tile_downloader=FakeTileDownloader(), frame=frame
         )
 
     monkeypatch.setattr(owntracks_maps, "render_day_map", _render)
@@ -151,10 +156,10 @@ def dt():
 
 def test_writes_a_location_section_into_the_note(db_with_locations, dt):
     joplin = FakeJoplin()
-    result = sync_day_map_to_note(
+    result, num_maps = sync_day_map_to_note(
         dt, session=db_with_locations, mydiary_joplin=joplin
     )
-    assert result == "updated"
+    assert (result, num_maps) == ("updated", 1)
 
     md = MarkdownDoc(joplin.note.body)
     section = md.get_section_by_title("Location")
@@ -181,7 +186,7 @@ def test_handwritten_words_are_untouched(db_with_locations, dt):
 def test_records_bookkeeping_row(db_with_locations, dt):
     joplin = FakeJoplin()
     sync_day_map_to_note(dt, session=db_with_locations, mydiary_joplin=joplin)
-    row = db_with_locations.get(OwnTracksDayMap, dt.date())
+    row = db_with_locations.get(OwnTracksDayMap, (dt.date(), 0))
     assert row is not None
     assert row.joplin_resource_id in joplin.resources
     assert row.num_stays == 3
@@ -211,7 +216,7 @@ def test_rerunning_an_unchanged_day_is_a_noop(db_with_locations, dt):
     sync_day_map_to_note(dt, session=db_with_locations, mydiary_joplin=joplin)
     assert joplin.update_count == 1
 
-    result = sync_day_map_to_note(
+    result, _ = sync_day_map_to_note(
         dt, session=db_with_locations, mydiary_joplin=joplin
     )
     assert result == "no update"
@@ -229,11 +234,11 @@ def test_force_replaces_the_resource_and_deletes_the_old_one(
     # a different render produces different bytes, hence a different resource
     real_render = owntracks_maps.render_day_map
 
-    def _bigger(track, params=None, render=None, tile_downloader=None):
+    def _bigger(track, params=None, render=None, tile_downloader=None, frame=None):
         return real_render(track, params, RenderParams(width=640, height=480))
 
     monkeypatch.setattr(owntracks_maps, "render_day_map", _bigger)
-    result = sync_day_map_to_note(
+    result, _ = sync_day_map_to_note(
         dt, session=db_with_locations, mydiary_joplin=joplin, force=True
     )
     assert result == "updated"
@@ -288,6 +293,215 @@ def test_section_content_without_a_resource_is_still_useful():
         num_points=3,
         distance_m=0.0,
     )
-    content = section_content(None, track)
+    panels = panels_for_track(track)
+    content = section_content([None], panels)
     assert "![](" not in content
     assert "2h" in content
+
+
+# --- days spent in more than one distinct area ------------------------------
+
+
+TWO_AREA_DAY = "2026-07-02"
+
+# open ocean, as everywhere else in this suite: ~3900km apart, the scale at
+# which one bounding box stops being able to frame a day
+HOME_LAT, HOME_LON = 33.500, -42.005
+FAR_LAT, FAR_LON = 26.782, -82.228
+
+
+@pytest.fixture
+def db_two_areas(db_session: Session):
+    """A long-haul day: a morning at HOME, an evening at FAR.
+
+    One bounding box cannot frame both -- the whole day is 3900km wide, so the
+    stays at the far end collapse into stacked circles on the overview.
+    """
+    base = pendulum.parse(TWO_AREA_DAY, tz=TZ)
+    fixes = [
+        (base.add(hours=8), HOME_LAT, HOME_LON),
+        (base.add(hours=9), HOME_LAT + 0.001, HOME_LON - 0.0005),
+        (base.add(hours=10), HOME_LAT + 0.0005, HOME_LON + 0.0005),
+        (base.add(hours=19), FAR_LAT, FAR_LON),
+        (base.add(hours=20), FAR_LAT + 0.0008, FAR_LON - 0.0009),
+        (base.add(hours=22), FAR_LAT + 0.0038, FAR_LON - 0.0079),
+        (base.add(hours=23), FAR_LAT + 0.0043, FAR_LON - 0.0084),
+    ]
+    for tst, lat, lon in fixes:
+        db_session.add(
+            OwnTracksLocation(
+                tst=tst.in_timezone("UTC"),
+                lat=lat,
+                lon=lon,
+                acc=10,
+                username="u",
+                device="d",
+            )
+        )
+    db_session.commit()
+    return db_session
+
+
+@pytest.fixture
+def dt_two_areas():
+    return pendulum.parse(TWO_AREA_DAY, tz=TZ)
+
+
+def test_a_single_area_day_hashes_as_it_did_before_panels_existed(
+    db_with_locations, dt
+):
+    # the guarantee that keeps 96% of days from churning: the one panel's track
+    # IS the whole day, so its hash is the value already stored in the database
+    from mydiary.owntracks_maps import _content_hash, panels_for_day
+    from mydiary.owntracks_track import TrackParams
+
+    track, panels = panels_for_day(dt, db_with_locations)
+    assert len(panels) == 1
+    assert panels[0].content_hash == _content_hash(
+        track, TrackParams(), RenderParams()
+    )
+
+
+def test_a_two_area_day_writes_an_overview_plus_one_map_per_area(
+    db_two_areas, dt_two_areas
+):
+    joplin = FakeJoplin()
+    result, num_maps = sync_day_map_to_note(
+        dt_two_areas, session=db_two_areas, mydiary_joplin=joplin
+    )
+    assert (result, num_maps) == ("updated", 3)
+
+    section = MarkdownDoc(joplin.note.body).get_section_by_title("Location")
+    assert len(section.get_resource_ids()) == 3
+    # each area gets its own heading and itinerary, and the level-3 heading does
+    # not split the Location section in two
+    assert section.content.count("### ") == 2
+    assert section.content.count("Arrive | Depart | Duration | Where") == 2
+    assert joplin.note.body.count("## Location") == 1
+
+
+def test_each_panel_gets_its_own_bookkeeping_row(db_two_areas, dt_two_areas):
+    joplin = FakeJoplin()
+    sync_day_map_to_note(
+        dt_two_areas, session=db_two_areas, mydiary_joplin=joplin
+    )
+    rows = list(
+        db_two_areas.exec(
+            select(OwnTracksDayMap)
+            .where(OwnTracksDayMap.diary_date == dt_two_areas.date())
+            .order_by(OwnTracksDayMap.panel)
+        )
+    )
+    assert [r.panel for r in rows] == [0, 1, 2]
+    assert len({r.content_hash for r in rows}) == 3
+    # panel 0 is the whole day; the areas hold its stays between them
+    assert rows[0].num_stays == rows[1].num_stays + rows[2].num_stays
+
+
+def test_rerunning_a_two_area_day_is_a_noop(db_two_areas, dt_two_areas):
+    joplin = FakeJoplin()
+    sync_day_map_to_note(dt_two_areas, session=db_two_areas, mydiary_joplin=joplin)
+    assert joplin.update_count == 1
+
+    result, _ = sync_day_map_to_note(
+        dt_two_areas, session=db_two_areas, mydiary_joplin=joplin
+    )
+    assert result == "no update"
+    assert joplin.update_count == 1
+    assert len(joplin.resources) == 3  # and no orphans
+
+
+def test_a_day_that_gains_areas_reuses_its_overview_resource(
+    db_two_areas, dt_two_areas, monkeypatch
+):
+    # what an already-synced flight day looks like when this lands: it has a
+    # panel-0 row already, and only the two area panels are new work
+    import mydiary.owntracks_maps as om
+
+    joplin = FakeJoplin()
+    original = om.split_into_areas
+    monkeypatch.setattr(om, "split_into_areas", lambda track, threshold_m=0: [])
+    sync_day_map_to_note(dt_two_areas, session=db_two_areas, mydiary_joplin=joplin)
+    assert len(joplin.resources) == 1
+    overview_id = next(iter(joplin.resources))
+
+    # restore by setattr rather than undo(), which would also roll back the
+    # autouse fixture's MYDIARY_CACHE_DIR and send tile writes at the real cache
+    monkeypatch.setattr(om, "split_into_areas", original)
+    result, num_maps = sync_day_map_to_note(
+        dt_two_areas, session=db_two_areas, mydiary_joplin=joplin
+    )
+    assert (result, num_maps) == ("updated", 3)
+    assert overview_id in joplin.resources  # reused, not re-uploaded
+    assert overview_id not in joplin.deleted
+    assert len(joplin.resources) == 3
+
+
+def test_the_map_route_can_select_a_panel(db_two_areas, dt_two_areas):
+    _, whole_day, _ = render_for_day(dt_two_areas, db_two_areas)
+    _, area, _ = render_for_day(dt_two_areas, db_two_areas, panel=1)
+    assert len(area.stays) < len(whole_day.stays)
+    with pytest.raises(LookupError):
+        render_for_day(dt_two_areas, db_two_areas, panel=9)
+
+
+def test_note_init_does_not_flatten_a_split_day_back_to_one_map(
+    db_two_areas, dt_two_areas
+):
+    # MyDiaryDay writes the Location section when a note is initialised, from
+    # its own stored rows. If it emitted one map for a day that is really three,
+    # sync_day_map_to_note would then find an unchanged hash and leave the note
+    # degraded -- silently, because nothing errors.
+    from mydiary.models import OwnTracksLocation
+    from mydiary.mydiary_day import MyDiaryDay
+
+    joplin = FakeJoplin()
+    sync_day_map_to_note(dt_two_areas, session=db_two_areas, mydiary_joplin=joplin)
+    rows = list(
+        db_two_areas.exec(
+            select(OwnTracksDayMap).where(
+                OwnTracksDayMap.diary_date == dt_two_areas.date()
+            )
+        )
+    )
+    day = MyDiaryDay(
+        dt=dt_two_areas,
+        owntracks_locations=list(db_two_areas.exec(select(OwnTracksLocation))),
+        owntracks_day_maps=rows,
+    )
+    markdown = day.owntracks_markdown()
+    assert markdown.count("![](") == 3
+    assert markdown.count("### ") == 2
+    for row in rows:
+        assert row.joplin_resource_id in markdown
+
+
+def test_the_panel_key_covers_how_it_is_framed():
+    # the frame decides the zoom, so it has to be part of the panel's identity.
+    # Without it, a day already in a note reports "no update" after a framing
+    # change and quietly keeps the superseded picture.
+    from mydiary.owntracks_maps import _area_key
+    from mydiary.owntracks_track import DayTrack, Link, Stay
+
+    base = pendulum.datetime(2026, 7, 1, 8, tz=TZ)
+    stay = Stay(HOME_LAT, HOME_LON, base, base.add(hours=6), 3)
+    leg = Link(
+        HOME_LAT,
+        HOME_LON,
+        HOME_LAT - 0.14,
+        HOME_LON - 0.05,
+        base,
+        base.add(minutes=30),
+        16000.0,
+        False,
+    )
+
+    class FakeArea:
+        def __init__(self, frame):
+            self.frame = frame
+
+    on_the_stay = FakeArea(DayTrack(stays=[stay]))
+    on_the_contents = FakeArea(DayTrack(stays=[stay], links=[leg]))
+
+    assert _area_key(0, on_the_stay) != _area_key(0, on_the_contents)
+    assert _area_key(0, on_the_stay) != _area_key(1, on_the_stay)

--- a/backend/tests/test_owntracks_track.py
+++ b/backend/tests/test_owntracks_track.py
@@ -304,3 +304,272 @@ def test_gap_stay_not_inferred_when_the_gap_covers_ground():
         TrackPoint(base.add(hours=1), 33.58, -42.0054),  # 9km in an hour
     ]
     assert detect_gap_stays(points, [], min_minutes=20, max_kmh=1.0) == []
+
+
+# --- areas -----------------------------------------------------------------
+#
+# A "distinct area" has to mean somewhere you actually were. That is why
+# clustering runs on stays and not on every point, and these tests exist mostly
+# to pin that down.
+#
+# Coordinates follow the convention of the rest of this suite and of the
+# owntracks_data fixtures: open ocean, nowhere anyone has been. HOME and FAR are
+# ~3900km apart, the scale at which a day genuinely needs more than one map.
+# 1 degree of latitude is ~111km anywhere; 1 degree of longitude is ~93km at
+# HOME and ~99km at FAR.
+
+HOME_LAT, HOME_LON = 33.500, -42.005
+FAR_LAT, FAR_LON = 26.782, -82.228
+
+
+def _stay(lat, lon, start, hours=2, num_points=3):
+    from mydiary.owntracks_track import Stay
+
+    return Stay(lat, lon, start, start.add(hours=hours), num_points)
+
+
+def _two_area_day():
+    """A morning at HOME, then a long haul to FAR, with a stay at each end."""
+    base = pendulum.datetime(2026, 7, 1, 8, tz=TZ)
+    return build_track(
+        [
+            TrackPoint(base, HOME_LAT, HOME_LON),
+            TrackPoint(base.add(hours=1), HOME_LAT + 0.001, HOME_LON - 0.0005),
+            TrackPoint(base.add(hours=9), FAR_LAT, FAR_LON),
+            TrackPoint(base.add(hours=12), FAR_LAT + 0.004, FAR_LON - 0.008),
+        ]
+    )
+
+
+def test_a_day_that_fits_one_frame_needs_no_areas():
+    # the common case: one map, exactly as before areas existed
+    from mydiary.owntracks_track import split_into_areas
+
+    base = pendulum.datetime(2026, 7, 1, 9, tz=TZ)
+    track = build_track(
+        [
+            TrackPoint(base, HOME_LAT, HOME_LON),
+            TrackPoint(base.add(hours=2), HOME_LAT + 0.001, HOME_LON - 0.0005),
+            TrackPoint(base.add(hours=4), HOME_LAT - 0.028, HOME_LON - 0.0095),
+        ]
+    )
+    assert split_into_areas(track) == []
+
+
+def test_a_long_haul_day_splits_into_two_areas_in_time_order():
+    from mydiary.owntracks_track import split_into_areas
+
+    areas = split_into_areas(_two_area_day())
+    assert len(areas) == 2
+    assert areas[0].t_start < areas[1].t_start
+    assert round(areas[0].track.stays[0].lon) == round(HOME_LON)
+    assert round(areas[1].track.stays[0].lon) == round(FAR_LON)
+
+
+def test_a_road_trip_is_one_area_even_though_its_waypoints_are_far_apart():
+    # the reason clustering runs on stays: consecutive waypoints along a drive
+    # are each tens of km apart, so clustering every point would report a single
+    # journey as a dozen areas
+    from mydiary.owntracks_track import split_into_areas
+
+    base = pendulum.datetime(2026, 7, 1, 9, tz=TZ)
+    points = [TrackPoint(base, HOME_LAT, HOME_LON)]
+    points.append(
+        TrackPoint(base.add(minutes=40), HOME_LAT + 0.0005, HOME_LON - 0.0005)
+    )  # a stay
+    for i in range(1, 12):  # ~11km apart each, none of them a stay
+        points.append(
+            TrackPoint(
+                base.add(hours=1, minutes=10 * i),
+                HOME_LAT + 0.0005 + 0.1 * i,
+                HOME_LON - 0.0005,
+            )
+        )
+    track = build_track(points)
+    assert len(track.links) > 5  # it really is a chain of far-apart waypoints
+    # the drive reaches well outside the one place the day stopped, so that
+    # place gets its own panel -- but the chain is never itself a crowd of areas
+    assert len(split_into_areas(track)) == 1
+
+
+def test_a_link_between_two_areas_belongs_to_neither():
+    from mydiary.owntracks_track import split_into_areas
+
+    track = _two_area_day()
+    areas = split_into_areas(track)
+    # the long haul is on the whole-day track but on neither panel, which is
+    # what keeps a panel's bounds local instead of 4000km wide
+    assert sum(len(a.track.links) for a in areas) < len(track.links)
+    for area in areas:
+        lons = [x.start_lon for x in area.track.links] + [
+            x.end_lon for x in area.track.links
+        ]
+        assert max(lons, default=0) - min(lons, default=0) < 1
+
+
+def test_area_labels_read_as_a_time_range():
+    from mydiary.owntracks_track import split_into_areas
+
+    assert split_into_areas(_two_area_day())[0].label() == "08:00–09:00"
+
+
+def test_an_empty_day_has_no_areas():
+    from mydiary.owntracks_track import split_into_areas
+
+    assert split_into_areas(build_track([])) == []
+
+
+def test_a_day_with_no_stays_at_all_needs_no_areas():
+    # pure transit: nowhere qualifies as a stay, so there is nothing to frame
+    # more tightly than the day itself
+    from mydiary.owntracks_track import split_into_areas
+
+    base = pendulum.datetime(2026, 7, 1, 9, tz=TZ)
+    track = build_track(
+        [
+            TrackPoint(base, HOME_LAT, HOME_LON),
+            TrackPoint(base.add(minutes=5), HOME_LAT + 0.042, HOME_LON + 0.0855),
+            TrackPoint(base.add(minutes=10), HOME_LAT + 0.092, HOME_LON + 0.1855),
+        ]
+    )
+    assert track.stays == []
+    assert split_into_areas(track) == []
+
+
+def test_cluster_stays_links_through_an_intermediate_stay():
+    # single linkage: the two ends are ~33km apart, but something sits between
+    # them, so it is one sprawling area rather than two
+    from mydiary.owntracks_track import cluster_stays
+
+    base = pendulum.datetime(2026, 7, 1, 9, tz=TZ)
+    stays = [
+        _stay(HOME_LAT - 0.15, HOME_LON, base),
+        _stay(HOME_LAT, HOME_LON, base.add(hours=3)),
+        _stay(HOME_LAT + 0.15, HOME_LON, base.add(hours=6)),
+    ]
+    assert len(cluster_stays(stays, threshold_m=20_000)) == 1
+    assert len(cluster_stays(stays, threshold_m=5_000)) == 3
+
+
+def test_a_long_haul_with_stays_at_only_one_end_still_gets_a_panel():
+    # the shape of a real flight day: setting off, the airport and the flight
+    # are all transit, so every stay is at the far end. Counting areas alone
+    # would call that one area and leave those stays stacked inside a 4000km
+    # frame -- the exact case this feature exists for.
+    from mydiary.owntracks_track import split_into_areas
+
+    base = pendulum.datetime(2026, 7, 1, 5, tz=TZ)
+    track = build_track(
+        [
+            TrackPoint(base, HOME_LAT, HOME_LON),  # setting off, then straight out
+            TrackPoint(base.add(minutes=30), HOME_LAT - 0.117, HOME_LON + 0.207),
+            TrackPoint(base.add(hours=10), FAR_LAT, FAR_LON),
+            TrackPoint(base.add(hours=12), FAR_LAT + 0.0005, FAR_LON - 0.0001),
+            TrackPoint(base.add(hours=14), FAR_LAT + 0.0228, FAR_LON - 0.0105),
+        ]
+    )
+    areas = split_into_areas(track)
+    assert len(areas) == 1
+    # and the panel frames the far end, not the journey
+    lons = [s.lon for s in areas[0].track.stays]
+    assert max(lons) - min(lons) < 1
+    assert areas[0].track is not track
+
+
+def test_an_area_is_framed_on_its_stays_not_on_the_leg_out_of_it():
+    # one stay, a ~16km leg that stays inside the area and a longer one that
+    # does not. Framing the panel on its contents zoomed back out to take in
+    # that leg, and the "closer" map came out all but identical to the overview.
+    from mydiary.owntracks_track import extent_m, split_into_areas
+
+    base = pendulum.datetime(2026, 7, 1, 8, tz=TZ)
+    track = build_track(
+        [
+            TrackPoint(base, HOME_LAT, HOME_LON),  # the one place it stopped
+            TrackPoint(base.add(hours=6), HOME_LAT + 0.0005, HOME_LON - 0.0005),
+            TrackPoint(
+                base.add(hours=6, minutes=30), HOME_LAT - 0.14, HOME_LON - 0.05
+            ),  # ~16km
+            TrackPoint(base.add(hours=7), HOME_LAT - 0.22, HOME_LON - 0.10),
+        ]
+    )
+    assert len(track.stays) == 1
+    areas = split_into_areas(track)
+    assert len(areas) == 1
+    # the leg is still drawn -- it just runs off the edge of the frame
+    assert areas[0].track.links
+    assert extent_m(areas[0].frame) < 0.05 * extent_m(track)
+
+
+def test_stays_spread_almost_as_wide_as_the_day_get_no_panel():
+    # the frame-gain floor: when the places themselves are strung out nearly the
+    # width of the day, a panel is the overview again and is not worth a map
+    from mydiary.owntracks_track import split_into_areas
+
+    base = pendulum.datetime(2026, 7, 1, 8, tz=TZ)
+    track = build_track(
+        [
+            TrackPoint(base, HOME_LAT, HOME_LON),
+            TrackPoint(base.add(hours=1), HOME_LAT + 0.0005, HOME_LON - 0.0005),
+            TrackPoint(base.add(hours=4), HOME_LAT + 0.15, HOME_LON),  # ~17km on
+            TrackPoint(base.add(hours=5), HOME_LAT + 0.1505, HOME_LON - 0.0005),
+            TrackPoint(base.add(hours=6), HOME_LAT + 0.18, HOME_LON),  # a bit past
+        ]
+    )
+    assert len(track.stays) == 2
+    assert split_into_areas(track) == []
+
+
+def test_extent_measures_the_longer_side_of_the_bounding_box():
+    from mydiary.owntracks_track import Stay, DayTrack, extent_m
+
+    base = pendulum.datetime(2026, 7, 1, 9, tz=TZ)
+    one_place = DayTrack(
+        stays=[Stay(HOME_LAT, HOME_LON, base, base.add(hours=2), 3)]
+    )
+    assert extent_m(one_place) == 0.0
+    spread = DayTrack(
+        stays=[
+            Stay(HOME_LAT, HOME_LON, base, base.add(hours=2), 3),
+            # 0.16 deg of longitude is ~14.9km at this latitude
+            Stay(HOME_LAT, HOME_LON + 0.16, base.add(hours=3), base.add(hours=5), 3),
+        ]
+    )
+    assert 14_000 < extent_m(spread) < 16_000
+
+
+def test_geojson_says_which_area_each_feature_belongs_to():
+    # this is what lets the day page draw the same set of maps the note gets,
+    # rather than one map of everything
+    from mydiary.owntracks_track import split_into_areas, track_to_geojson
+
+    track = _two_area_day()
+    areas = split_into_areas(track)
+    gj = track_to_geojson(track, areas)
+
+    assert gj["properties"]["num_maps"] == 1 + len(areas)
+    assert [a["index"] for a in gj["properties"]["areas"]] == list(range(len(areas)))
+    # every stay belongs to exactly one area; the leg between them to none
+    stays = [f for f in gj["features"] if f["properties"]["kind"] == "stay"]
+    assert all(f["properties"]["area"] is not None for f in stays)
+    assert any(f["properties"]["area"] is None for f in gj["features"])
+    # and the bounds handed over are the frame, so a panel drawn to them is
+    # zoomed on the stays rather than on the journey
+    for area, described in zip(areas, gj["properties"]["areas"]):
+        assert described["bounds"] == area.frame.bounds()
+
+
+def test_geojson_without_areas_marks_nothing():
+    from mydiary.owntracks_track import track_to_geojson
+
+    base = pendulum.datetime(2026, 7, 1, 9, tz=TZ)
+    track = build_track(
+        [
+            TrackPoint(base, HOME_LAT, HOME_LON),
+            TrackPoint(base.add(hours=2), HOME_LAT + 0.001, HOME_LON - 0.0005),
+        ]
+    )
+    gj = track_to_geojson(track)
+    assert gj["properties"]["num_maps"] == 1
+    assert gj["properties"]["areas"] == []
+    assert all(f["properties"]["area"] is None for f in gj["features"])

--- a/docs/location-workflow.md
+++ b/docs/location-workflow.md
@@ -31,8 +31,9 @@ everything downstream:
 
 ```
 recorder ──> OwnTracksLocation ──> owntracks_track ──> map_render ──> Joplin
-  (API)         (SQLite)            (stays/links)       (JPEG)      (Location §)
-                                          │
+  (API)         (SQLite)         (stays/links/areas)    (JPEG)      (Location §)
+                                          │                ^
+                                          │        one panel per area
                                           └──> /owntracks/track/{dt} ──> MapSection.vue
 ```
 
@@ -130,6 +131,69 @@ Two things that are easy to get wrong here:
 query parameter — and `cache_key()` normalises the format name so `jpg` and
 `JPEG` do not hash as two different encodings.
 
+### One map, or several
+
+One bounding box per day fails on a day that spans distant places: the frame is
+sized by the whole journey, so the local detail disappears. A transcontinental
+flight day puts a whole continent in frame, and the five stays at the far end
+collapse into stacked concentric circles; the widest day in the data is 5889km.
+The crop-to-content trick recovers framing *within* one cluster, but nothing can
+make one frame both 4000km wide and street-legible.
+
+So `split_into_areas` clusters the day and each area gets its own panel, with
+the whole-day overview kept as panel 0 — on a flight day "I went from here to
+there" is real information, it just cannot also carry the local detail. Small
+multiples, not either/or. Measured over the 318 days with a drawable track:
+
+| Maps | Days | |
+|---|---|---|
+| 1 | 273 | 85.8% — unchanged, and unchanged *byte for byte* |
+| 2 | 15 | 4.7% |
+| 3 | 28 | 8.8% |
+| 4 | 2 | 0.6% |
+
+Four things about the split are load-bearing:
+
+- **It runs on stays, never on all points.** Consecutive waypoints along a drive
+  are each tens of km apart, so clustering every point counts a chain as a
+  crowd: at a 5km threshold over all points, one road-trip day reports **66**
+  areas for what is a single drive. A "distinct area" has to mean somewhere you actually
+  were, not somewhere you passed. Transit links connect areas; they are never
+  areas themselves, and a link between two areas is drawn on the overview only —
+  putting it on a panel would blow that panel's bounds out to the whole journey.
+- **The number of areas is not on its own what decides the split.** A flight day
+  can have *every* stay at the far end: setting off, the airport and the flight
+  are all transit, and none of them dwells long enough to be a stay. Counted by
+  areas alone that is one area, and the very day this feature exists for would
+  have got one 4000km-wide map. So a single area still earns a
+  panel once anything drawn reaches more than `AREA_SPLIT_M` outside it — the
+  question is whether the overview *frames* the areas or dwarfs them. That case
+  is 15 of the 45 multi-map days, including both flights.
+- **A panel is framed on its stays, not on its contents** — the one thing that
+  makes the panels worth having. An area holds the legs that run within it, and
+  one of those can be 16km long; fitting the map to *that* zooms back out until
+  the panel is the overview again. One day in the data was exactly this — a 16km
+  leg inside the area, a longer one outside it, and two maps that looked
+  identical.
+  Framing on the stays puts the panel where the day actually was and lets the
+  leg run off the edge, which reads correctly as leaving. `render_day_map` takes
+  `frame` separately from `track` for this.
+- **The frame is part of the panel's content hash** (`_area_key`). It decides
+  the zoom, so a change to how panels are framed has to make every stored area
+  panel stale; otherwise a re-sync reports "no update" and leaves the previous
+  picture in the note. The overview's hash is untouched by it, so only the area
+  panels re-render.
+- **`FRAME_GAIN` (0.5) is a floor, not a filter.** If the stays themselves are
+  strung out nearly as wide as the day, framing on them gains nothing and the
+  split is dropped whole — all or nothing, so every stay stays covered by
+  exactly one itinerary. No day in the current data trips it (the loosest panel
+  frames at 0.26 of its day); it exists so a degenerate day cannot produce two
+  copies of the same picture.
+- **`AREA_SPLIT_M` (20km) is not a `TrackParams` field**, deliberately.
+  `TrackParams.cache_key()` feeds the stored content hash, so adding a field
+  there would change the hash of every day in the database and rewrite every
+  note on the next sync.
+
 ### Visual encoding
 
 Time of day is **four labelled periods, not a continuous gradient** — on a map
@@ -165,11 +229,20 @@ beneath. Only stays over an hour get a duration label.
 - Uploads via `create_resource`, **not** `create_thumbnail` — the latter's 60KB
   ceiling would destroy the map. No `MyDiaryImage` row is created either, or the
   map would leak into the photo grid and the Images section.
-- `OwnTracksDayMap` records `content_hash` — `sha256` over the track's own hash
-  plus `RenderParams.cache_key()`, composed in `render_for_day` rather than in
+- `OwnTracksDayMap` is one row **per panel** — `(diary_date, panel)` is the
+  primary key, and panel 0 is the overview every day has. It records
+  `content_hash` — `sha256` over that panel's track hash plus
+  `RenderParams.cache_key()`, composed in `owntracks_maps` rather than in
   `owntracks_track`, which is pure track maths and should not know about image
   encoding. An unchanged re-run is a no-op; a changed one creates the new
   resource and deletes the old, so re-rendering never orphans resources.
+  A panel whose hash is unchanged keeps its resource, so a day that gains areas
+  re-uploads only the new panels.
+
+  **A one-area day's only panel is the whole day**, so it hashes to exactly what
+  a day map hashed to before panels existed — which is why 96% of days were not
+  invalidated when this landed, and why the overview of a multi-area day reuses
+  the resource it already had.
   Because the render params are in the hash, changing the size or the format is
   enough on its own to invalidate every stored day — which is what makes
   `scripts/owntracks_reencode_maps.py` work without `force`, and makes it
@@ -180,17 +253,32 @@ beneath. Only stays over an hour get a duration label.
   `update_joplin_note` skips sections it does not find. `MarkdownDoc.ensure_section`
   is what backfills it.
 - The section holds the map **and** a text itinerary. The itinerary is the part
-  that keeps working: Joplin can search text, it cannot search an image.
+  that keeps working: Joplin can search text, it cannot search an image. A
+  multi-area day leads with the overview and the day summary, then gives each
+  area a `###` heading, its own map and its own itinerary — level 3, because
+  `MarkdownDoc` splits on `## ` and the Location section has to stay one
+  section. There is no day-level table in that case: every stay belongs to
+  exactly one area, so it would only repeat the per-area ones.
+- `MyDiaryDay.owntracks_markdown` re-derives the panels rather than trusting the
+  stored rows, so initialising a note for a day that is already split cannot
+  flatten it back to one map — `sync_day_map_to_note` would then see an
+  unchanged hash and leave the note that way.
+- `MapSection.vue` draws the same set: one Leaflet map for the whole day, then
+  one per area, framed the way the saved panels are. It filters the track
+  GeoJSON on each feature's `area`, which is why that endpoint tags them — a
+  preview showing one map for a day that saves as three is a preview of the
+  wrong thing.
 
 ## Routes
 
 | Route | operation_id |
 |---|---|
 | `GET /owntracks/locations/{dt}` | `owntracksLocationsForDay` — raw fixes |
-| `GET /owntracks/track/{dt}` | `owntracksTrackForDay` — processed stays + links |
-| `GET /owntracks/map/{dt}` | `owntracksDayMapImage` — JPEG by default; `fmt` / `quality` / `width` / `height` |
+| `GET /owntracks/track/{dt}` | `owntracksTrackForDay` — processed stays + links, each tagged with its area, plus `properties.areas` |
+| `GET /owntracks/map/{dt}` | `owntracksDayMapImage` — JPEG by default; `fmt` / `quality` / `width` / `height` / `panel` |
+| `GET /owntracks/areas/{dt}` | `owntracksAreasForDay` — the day's distinct areas, and how many maps it needs |
 | `POST /owntracks/sync` | `owntracksSyncLocations` |
-| `POST /owntracks/map/{dt}/to_note` | `owntracksMapToNote` |
+| `POST /owntracks/map/{dt}/to_note` | `owntracksMapToNote` — returns `num_maps` |
 
 The track and map routes take every `TrackParams` threshold as a query
 parameter, which is what the frontend tuning sliders drive.

--- a/mydiary-vuetify/src/api.ts
+++ b/mydiary-vuetify/src/api.ts
@@ -392,6 +392,7 @@ tz?: string;
 
 export type OwntracksTrackForDayParams = {
 tz?: string;
+area_threshold_m?: number;
 max_acc?: number;
 stay_radius_m?: number;
 stay_minutes?: number;
@@ -406,6 +407,18 @@ width?: number;
 height?: number;
 fmt?: string;
 quality?: number;
+panel?: number;
+max_acc?: number;
+stay_radius_m?: number;
+stay_minutes?: number;
+gap_minutes?: number;
+gap_metres?: number;
+dwell_max_kmh?: number;
+};
+
+export type OwntracksAreasForDayParams = {
+tz?: string;
+area_threshold_m?: number;
 max_acc?: number;
 stay_radius_m?: number;
 stay_minutes?: number;
@@ -809,8 +822,9 @@ export const owntracksLocationsForDay = (
 /**
  * The processed day: stays and links, as GeoJSON.
  *
- * The frontend map draws this, so the interactive view and the rendered PNG
- * always agree.
+ * The frontend map draws this, so the interactive view and the rendered image
+ * always agree -- including how many maps the day is in: every feature carries
+ * the index of the area it belongs to, and `properties.areas` describes them.
  * @summary Owntracks Track For Day
  */
 export const owntracksTrackForDay = (
@@ -825,6 +839,8 @@ export const owntracksTrackForDay = (
   }
 
 /**
+ * The day's map. Panel 0 is the whole day; on a day spent in two or more
+ * distinct areas, higher panels are the per-area maps.
  * @summary Owntracks Day Map Image
  */
 export const owntracksDayMapImage = (
@@ -834,6 +850,24 @@ export const owntracksDayMapImage = (
     return axios.get(
       `/owntracks/map/${dt}`,{
         responseType: 'blob',
+    ...options,
+        params: {...params, ...options?.params},}
+    );
+  }
+
+/**
+ * The parts of the day worth framing separately, empty when one map fits.
+ *
+ * Clustering runs on stays only: a road trip's waypoints are each far apart,
+ * so clustering every point would report a single drive as dozens of areas.
+ * @summary Owntracks Areas For Day
+ */
+export const owntracksAreasForDay = (
+    dt: string,
+    params?: OwntracksAreasForDayParams, options?: AxiosRequestConfig
+ ): Promise<AxiosResponse<unknown>> => {
+    return axios.get(
+      `/owntracks/areas/${dt}`,{
     ...options,
         params: {...params, ...options?.params},}
     );
@@ -854,7 +888,7 @@ export const owntracksSyncLocations = (
   }
 
 /**
- * Render the day's map and write it into the note's Location section.
+ * Render the day's map(s) and write them into the note's Location section.
  * @summary Owntracks Map To Note
  */
 export const owntracksMapToNote = (
@@ -1322,6 +1356,7 @@ export type NextcloudThumbnailImgResult = AxiosResponse<unknown | Blob>
 export type OwntracksLocationsForDayResult = AxiosResponse<unknown>
 export type OwntracksTrackForDayResult = AxiosResponse<unknown>
 export type OwntracksDayMapImageResult = AxiosResponse<unknown | Blob>
+export type OwntracksAreasForDayResult = AxiosResponse<unknown>
 export type OwntracksSyncLocationsResult = AxiosResponse<unknown>
 export type OwntracksMapToNoteResult = AxiosResponse<unknown>
 export type UploadImagesToNoteResult = AxiosResponse<MyDiaryImageRead[]>

--- a/mydiary-vuetify/src/components/MapSection.vue
+++ b/mydiary-vuetify/src/components/MapSection.vue
@@ -48,7 +48,24 @@
             </v-card>
         </v-expand-transition>
 
-        <div ref="mapEl" class="mydiary-map mt-2" />
+        <div ref="overviewEl" class="mydiary-map mt-2" />
+
+        <!-- a day spent in two or more distinct areas is saved as several maps:
+             this whole-day one, then a panel per area. Show what will be saved. -->
+        <div v-if="areas.length" class="area-panels mt-3">
+            <figure v-for="area in areas" :key="area.index" class="ma-0">
+                <div
+                    :ref="(el) => setAreaEl(area.index, el)"
+                    class="mydiary-map mydiary-map--panel"
+                />
+                <figcaption
+                    class="d-flex flex-wrap ga-2 mt-1 text-caption text-medium-emphasis"
+                >
+                    <span class="font-weight-medium">{{ area.label }}</span>
+                    <span>{{ areaSummary(area) }}</span>
+                </figcaption>
+            </figure>
+        </div>
 
         <div class="d-flex flex-wrap ga-4 mt-2">
             <div
@@ -70,11 +87,29 @@
         >
             {{ error }}
         </v-alert>
+
+        <v-alert
+            v-if="notice"
+            class="mt-2"
+            type="success"
+            closable
+            @click:close="notice = ''"
+        >
+            {{ notice }}
+        </v-alert>
     </section>
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
+import {
+    computed,
+    nextTick,
+    onBeforeUnmount,
+    onMounted,
+    reactive,
+    ref,
+    watch,
+} from 'vue'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 import { owntracksMapToNote, owntracksTrackForDay } from '@/api'
@@ -123,6 +158,7 @@ const showTuning = ref(false)
 const loading = ref(false)
 const syncing = ref(false)
 const error = ref('')
+const notice = ref('')
 const summary = ref('')
 const hasTrack = ref(false)
 
@@ -132,13 +168,57 @@ const hasNote = computed<boolean>(
 )
 
 const headerMeta = computed<string>(() => {
-    if (summary.value) return summary.value
-    return loading.value ? '' : 'No location data for this day'
+    if (!summary.value) return loading.value ? '' : 'No location data for this day'
+    // say how many maps this day saves as, since that is no longer always one
+    if (!areas.value.length) return summary.value
+    return `${summary.value} · ${areas.value.length + 1} maps`
 })
 
-const mapEl = ref<HTMLElement | null>(null)
+type Area = {
+    index: number
+    label: string
+    num_stays: number
+    distance_m: number
+    bounds: [number, number, number, number] | null
+}
+
+const overviewEl = ref<HTMLElement | null>(null)
+const areas = ref<Area[]>([])
 let map: L.Map | null = null
 let layer: L.LayerGroup | null = null
+// one Leaflet instance per area panel, keyed by area index
+const areaEls = new Map<number, HTMLElement>()
+const areaMaps = new Map<number, { map: L.Map; layer: L.LayerGroup }>()
+let features: any[] = []
+
+function setAreaEl(index: number, el: unknown) {
+    const node = (el as HTMLElement | null) ?? null
+    if (node) areaEls.set(index, node)
+    else {
+        areaMaps.get(index)?.map.remove()
+        areaMaps.delete(index)
+        areaEls.delete(index)
+    }
+}
+
+function areaSummary(area: Area): string {
+    const km = area.distance_m / 1000
+    const distance = km >= 0.1 ? `${km.toFixed(1)} km` : `${area.distance_m} m`
+    return `${distance} · ${area.num_stays} stop${area.num_stays === 1 ? '' : 's'}`
+}
+
+function basemap(target: L.Map): L.Map {
+    L.tileLayer(
+        'https://{s}.basemaps.cartocdn.com/rastertiles/light_all/{z}/{x}/{y}{r}.png',
+        {
+            subdomains: 'abcd',
+            maxZoom: 20,
+            attribution:
+                '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+        },
+    ).addTo(target)
+    return target
+}
 
 function resetParams() {
     Object.assign(params, DEFAULTS)
@@ -158,6 +238,90 @@ function stayRadius(minutes: number): number {
     return Math.min(40, Math.max(8, 2.2 * Math.sqrt(Math.max(minutes, 0))))
 }
 
+/** Draw the given features into a layer, returning what they cover. */
+function drawInto(target: L.LayerGroup, feats: any[]): L.LatLngBounds {
+    const bounds = L.latLngBounds([])
+    for (const f of feats) {
+        const p = f.properties
+        if (p.kind === 'link') {
+            const coords = f.geometry.coordinates.map(
+                (c: number[]) => [c[1], c[0]] as [number, number],
+            )
+            L.polyline(coords, {
+                color: p.color,
+                weight: 3,
+                opacity: p.uncertain ? 0.4 : 1,
+                // a dashed link means the route is genuinely unknown
+                dashArray: p.uncertain ? '7 6' : undefined,
+            })
+                .bindTooltip(
+                    `${p.t_start.slice(11, 16)}–${p.t_end.slice(11, 16)} · ${p.distance_m} m` +
+                        (p.uncertain ? ' · route unknown' : ''),
+                )
+                .addTo(target)
+            coords.forEach((c: [number, number]) => bounds.extend(c))
+        } else {
+            const [lon, lat] = f.geometry.coordinates
+            L.circleMarker([lat, lon], {
+                radius: stayRadius(p.duration_minutes),
+                color: p.color,
+                weight: 2,
+                opacity: 0.85,
+                fillColor: p.color,
+                fillOpacity: 0.22,
+            })
+                .bindTooltip(
+                    `${p.t_start.slice(11, 16)}–${p.t_end.slice(11, 16)} · ${p.duration_label}`,
+                )
+                .addTo(target)
+            bounds.extend([lat, lon])
+        }
+    }
+    return bounds
+}
+
+/** Panels are framed on their stays, as the saved images are, so the leg out of
+ *  an area runs off the edge instead of dragging the zoom back out. */
+function frameOn(target: L.Map, area: Area, fallback: L.LatLngBounds) {
+    const b = area.bounds
+    if (!b) {
+        if (fallback.isValid()) target.fitBounds(fallback, { padding: [40, 40] })
+        return
+    }
+    const [minLat, minLon, maxLat, maxLon] = b
+    if (minLat === maxLat && minLon === maxLon) {
+        // a single stay has no extent; 15 is where the renderer clamps too
+        target.setView([minLat, minLon], 15)
+        return
+    }
+    target.fitBounds(
+        L.latLngBounds([minLat, minLon], [maxLat, maxLon]),
+        { padding: [40, 40] },
+    )
+}
+
+async function drawAreaPanels() {
+    await nextTick()
+    for (const area of areas.value) {
+        const el = areaEls.get(area.index)
+        if (!el) continue
+        let panel = areaMaps.get(area.index)
+        if (!panel) {
+            const m = basemap(L.map(el, { scrollWheelZoom: false }))
+            panel = { map: m, layer: L.layerGroup().addTo(m) }
+            areaMaps.set(area.index, panel)
+        }
+        panel.layer.clearLayers()
+        const covered = drawInto(
+            panel.layer,
+            features.filter((f) => f.properties.area === area.index),
+        )
+        frameOn(panel.map, area, covered)
+        // the div is sized by layout that may not have settled when it was made
+        panel.map.invalidateSize()
+    }
+}
+
 async function loadTrack() {
     if (!map || !layer) return
     loading.value = true
@@ -165,48 +329,25 @@ async function loadTrack() {
     try {
         const gj = (await owntracksTrackForDay(props.dt, params)).data as any
         layer.clearLayers()
+        features = gj.features
         summary.value = gj.features.length ? formatSummary(gj.properties) : ''
         hasTrack.value = gj.features.length > 0
-        if (!gj.features.length) return
 
-        const bounds = L.latLngBounds([])
-        for (const f of gj.features) {
-            const p = f.properties
-            if (p.kind === 'link') {
-                const coords = f.geometry.coordinates.map(
-                    (c: number[]) => [c[1], c[0]] as [number, number],
-                )
-                L.polyline(coords, {
-                    color: p.color,
-                    weight: 3,
-                    opacity: p.uncertain ? 0.4 : 1,
-                    // a dashed link means the route is genuinely unknown
-                    dashArray: p.uncertain ? '7 6' : undefined,
-                })
-                    .bindTooltip(
-                        `${p.t_start.slice(11, 16)}–${p.t_end.slice(11, 16)} · ${p.distance_m} m` +
-                            (p.uncertain ? ' · route unknown' : ''),
-                    )
-                    .addTo(layer)
-                coords.forEach((c: [number, number]) => bounds.extend(c))
-            } else {
-                const [lon, lat] = f.geometry.coordinates
-                L.circleMarker([lat, lon], {
-                    radius: stayRadius(p.duration_minutes),
-                    color: p.color,
-                    weight: 2,
-                    opacity: 0.85,
-                    fillColor: p.color,
-                    fillOpacity: 0.22,
-                })
-                    .bindTooltip(
-                        `${p.t_start.slice(11, 16)}–${p.t_end.slice(11, 16)} · ${p.duration_label}`,
-                    )
-                    .addTo(layer)
-                bounds.extend([lat, lon])
+        // drop panels for areas this day no longer has before rebuilding
+        const next: Area[] = gj.features.length ? (gj.properties.areas ?? []) : []
+        for (const [index, panel] of areaMaps) {
+            if (!next.some((a) => a.index === index)) {
+                panel.map.remove()
+                areaMaps.delete(index)
+                areaEls.delete(index)
             }
         }
+        areas.value = next
+        if (!gj.features.length) return
+
+        const bounds = drawInto(layer, gj.features)
         if (bounds.isValid()) map.fitBounds(bounds, { padding: [40, 40] })
+        await drawAreaPanels()
     } catch (e: any) {
         error.value =
             e?.response?.data?.detail ||
@@ -214,6 +355,7 @@ async function loadTrack() {
             'Could not load location data'
         summary.value = ''
         hasTrack.value = false
+        areas.value = []
     } finally {
         loading.value = false
     }
@@ -223,8 +365,19 @@ async function onSyncToNote() {
     if (!hasNote.value) return
     syncing.value = true
     error.value = ''
+    notice.value = ''
     try {
-        await owntracksMapToNote(props.dt, {})
+        const r = (await owntracksMapToNote(props.dt, {})).data as {
+            result: string
+            num_maps: number
+        }
+        // a day spent in two or more distinct areas gets a map each, plus the
+        // whole-day overview, so say how many actually landed
+        const maps = r.num_maps === 1 ? 'the map' : `${r.num_maps} maps`
+        notice.value =
+            r.result === 'no update'
+                ? `The note already has ${maps}`
+                : `Added ${maps} to the note`
     } catch (e: any) {
         error.value =
             e?.response?.data?.detail ||
@@ -236,22 +389,21 @@ async function onSyncToNote() {
 }
 
 onMounted(() => {
-    if (!mapEl.value) return
-    map = L.map(mapEl.value, { scrollWheelZoom: false }).setView([40.77, -73.96], 13)
-    L.tileLayer(
-        'https://{s}.basemaps.cartocdn.com/rastertiles/light_all/{z}/{x}/{y}{r}.png',
-        {
-            subdomains: 'abcd',
-            maxZoom: 20,
-            attribution:
-                '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
-        },
-    ).addTo(map)
+    if (!overviewEl.value) return
+    // a world view, not a home one: the map refits to the day's track as soon
+    // as it loads, so this is only ever a placeholder, and a real centre here
+    // would be a location baked into a public repo
+    map = basemap(
+        L.map(overviewEl.value, { scrollWheelZoom: false }).setView([0, 0], 2),
+    )
     layer = L.layerGroup().addTo(map)
     loadTrack()
 })
 
 onBeforeUnmount(() => {
+    for (const panel of areaMaps.values()) panel.map.remove()
+    areaMaps.clear()
+    areaEls.clear()
     map?.remove()
     map = null
     layer = null
@@ -262,6 +414,17 @@ watch(params, loadTrack, { deep: true })
 </script>
 
 <style scoped>
+/* the area panels sit side by side where there is room, and stack on a phone */
+.area-panels {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.mydiary-map--panel {
+    height: 260px;
+}
+
 .mydiary-map {
     height: 420px;
     width: 100%;


### PR DESCRIPTION
## Why

One bounding box per day means a day that spans distant places renders at a zoom where all the local detail disappears. A transcontinental flight day puts a whole continent in frame and the stays at the far end collapse into stacked concentric circles you cannot read; the widest day in the data is 5889 km. The crop-to-content trick recovers framing *within* one cluster, but nothing makes one frame both 4000 km wide and street-legible.

These are exactly the days most worth looking at later, and they were the ones rendering worst.

## What this does

A day is split into areas, and each gets its own panel alongside the whole-day overview — small multiples, not either/or, because on a flight day "I went from here to there" is real information that just can't also carry the local detail.

Measured over the 318 days with a drawable track:

| Maps | Days | |
|---|---|---|
| 1 | 273 | 85.8% — unchanged, and unchanged *byte for byte* |
| 2 | 15 | 4.7% |
| 3 | 28 | 8.8% |
| 4 | 2 | 0.6% |

## Three decisions worth reviewing

**Clustering runs on stays, never on all points.** Consecutive waypoints along a drive are each tens of km apart, so clustering every point counts a chain as a crowd — at a 5 km threshold over all points, one road-trip day reports **66** areas for a single drive. A "distinct area" has to mean somewhere you actually were, not somewhere you passed.

**The number of areas doesn't decide the split on its own.** A flight day can have *every* stay at the far end: setting off, the airport and the flight are all transit, and none dwells long enough to register. Counted by areas alone that's one area — and the very day this feature exists for would have got one 4000 km-wide map. So a single area still earns a panel once anything drawn reaches more than `AREA_SPLIT_M` outside it.

**A panel is framed on its stays, not its contents.** An area holds the legs that run within it, and one of those can be 16 km long; fitting the map to *that* zooms back out until the panel is the overview again — which produced two near-identical maps on one day during development. `render_day_map` now takes `frame` separately from `track`, so the panel sits where the day actually was and the leg runs off the edge, which reads correctly as leaving.

## Schema — needs a migration

`OwnTracksDayMap` moves from `diary_date` to `(diary_date, panel)`. SQLite can't alter a primary key in place, so the migration rebuilds the table; existing rows become `panel = 0`, the overview, which is what they already were.

```sh
docker compose exec backend alembic upgrade head
```

**No already-synced day is invalidated.** A one-area day's only panel *is* the whole day, so it hashes to exactly what it hashed to before panels existed — verified against the real database, where every previously-synced day still reports `no update`. On a multi-area day the overview hashes the same way too, so it reuses its existing Joplin resource and only the new area panels upload.

The frame is part of an area panel's hash (`_area_key`), so a future change to framing makes stored panels stale instead of leaving a superseded picture in the note. Days already holding area panels re-render on their next sync.

## UI

The day page previews the same set of maps the note will get: the whole-day Leaflet map, then one per area, framed the way the saved panels are, captioned with each area's time range and its own distance and stop count. The header says how many maps the day saves as.

To make that possible, `/owntracks/track/{dt}` now tags every feature with the index of the area it belongs to (`null` for a link *between* areas) and describes the areas in `properties.areas` — so the interactive view and the rendered images stay derived from one source.

New route `GET /owntracks/areas/{dt}` returns the decomposition on its own, which is what makes the clustering inspectable without opening Joplin.

## Test data is anonymized on purpose

New test cases follow the convention the fixtures already used — coordinates in open ocean, not real places — built from `HOME`/`FAR` constants ~3900 km apart. This repo is public and the diary isn't, so `CLAUDE.md` now states that as a requirement, with the degree-to-km scales for writing new cases and a pre-commit grep that catches any coordinate precise enough to be real.

`MapSection.vue` also no longer hard-codes a real map centre; it opens on a world view and refits to the track.

## Verification

- Backend suite 222 passing (200 on `main`). The 6 failures and 3 errors are identical on `main` — all credential/env-related when run outside the container.
- Frontend builds; lint unchanged at its 26 pre-existing errors.
- Migration round-trips (`upgrade` → `downgrade` → `upgrade`) against a copy of the real database.
- End to end: the area decomposition checked on real multi-area days, both panels of a flight day rendered and inspected, and the day page driven at 1440×900 and 390×844 — including stepping between a 3-map and a 1-map day, which is the path that could leak Leaflet instances.

## Not in this PR

Stepping days with ‹ › throws in `MyDiaryDayDatePicker` and leaves the calendar highlight behind. It reproduces on `main`, so it's unrelated; it's written up in `notes/todo.md` as `[datepicker-route-error]` with the cause (a module-level `computed` calling `useRoute()` in its getter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
